### PR TITLE
Do not automatically include sources with all dependencies (lihaoyi#763)

### DIFF
--- a/amm/runtime/src/main/scala/ammonite/runtime/tools/IvyThing.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/tools/IvyThing.scala
@@ -49,7 +49,6 @@ object IvyThing{
           .withLogger(if (verbose) RefreshLogger.create() else CacheLogger.nop)
       )
       .withMainArtifacts()
-      .addClassifiers(Classifier.sources)
 
     Function.chain(hooks)(fetch).eitherResult() match {
       case Left(err) => Left("Failed to resolve ivy dependencies:" + err.getMessage)


### PR DESCRIPTION
Every dependency can include classifiers (tests, javadoc, sources). The line `.addClassifiers(Classifier.sources)` forces the inclusion of sources with _every_ dependency.
Removing this line prevents the automatic inclusion of sources that is causing strange issues (such as Hadoop libraries not functioning properly).
If you want sources with a dependency they'll need to be explicitly specified.