### PR TITLE
Use latest Scala 2.13 for build and use a test matrix in CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -7,7 +7,12 @@ on:
     branches:
       - master
 jobs:
-  unit-11-2_12_13:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: [8, 11]
+        scala-version: [2.12.13, 2.13.5]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -15,9 +20,14 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@v1
         with:
-          java-version: '11'
-      - run: ./mill -i unitTest 2.12.13
-  unit-8-2_12_13:
+          java-version: ${{ matrix.java-version }}
+      - run: ./mill -i unitTest "${{ matrix.scala-version }}"
+  itest:
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: [8, 11]
+        scala-version: [2.12.13, 2.13.5]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -25,48 +35,5 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@v1
         with:
-          java-version: '8'
-      - run: ./mill -i unitTest 2.12.13
-
-  unit-8-2_13_4:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-java@v1
-        with:
-          java-version: '8'
-      - run: ./mill -i unitTest 2.13.4
-
-  integration-11-2_12_13:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-java@v1
-        with:
-          java-version: '11'
-      - run: ./mill -i integrationTest 2.12.13
-  integration-8-2_12_13:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-java@v1
-        with:
-          java-version: '8'
-      - run: ./mill -i integrationTest 2.12.13
-
-  integration-8-2_13_4:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-java@v1
-        with:
-          java-version: '8'
-      - run: ./mill -i integrationTest 2.13.4
+          java-version: ${{ matrix.java-version }}
+      - run: ./mill -i integrationTest ${{ matrix.scala-version }}

--- a/build.sc
+++ b/build.sc
@@ -5,7 +5,7 @@ import $file.ci.upload
 import $ivy.`io.get-coursier::coursier-launcher:2.0.0-RC6-10`
 
 val isMasterCommit =
-  sys.env.get("GITHUB_REPOSITORY") == Some("lihaoyi/Ammonite") &&
+  sys.env.get("GITHUB_REPOSITORY") == Some("com-lihaoyi/Ammonite") &&
   sys.env.get("GITHUB_REF").exists(x => x.endsWith("/master"))
 
 val latestTaggedVersion = os.proc('git, 'describe, "--abbrev=0", "--tags").call().out.trim
@@ -21,14 +21,14 @@ val commitsSinceTaggedVersion = {
 }
 
 
-val binCrossScalaVersions = Seq("2.12.13", "2.13.4")
+val scala2_12Versions = Seq("2.12.1", "2.12.2", "2.12.3", "2.12.4", "2.12.6", "2.12.7", "2.12.8", "2.12.9", "2.12.10", "2.12.11", "2.12.12", "2.12.13")
+val scala2_13Versions = Seq("2.13.0", "2.13.1", "2.13.2", "2.13.3", "2.13.4", "2.13.5")
+
+val binCrossScalaVersions = Seq(scala2_12Versions.last, scala2_13Versions.last)
 def isScala2_12_10OrLater(sv: String): Boolean = {
   (sv.startsWith("2.12.") && sv.stripPrefix("2.12.").length > 1) || (sv.startsWith("2.13.") && sv != "2.13.0")
 }
-val fullCrossScalaVersions = Seq(
-  "2.12.1", "2.12.2", "2.12.3", "2.12.4", "2.12.6", "2.12.7", "2.12.8", "2.12.9", "2.12.10", "2.12.11", "2.12.12", "2.12.13",
-  "2.13.0", "2.13.1", "2.13.2", "2.13.3", "2.13.4", "2.13.5"
-)
+val fullCrossScalaVersions = scala2_12Versions ++ scala2_13Versions
 
 val latestAssemblies = binCrossScalaVersions.map(amm(_).assembly)
 


### PR DESCRIPTION
This is my attempt to finish the Scala 2.13.5 bump and also properly test it. See #1159 

I switched to a test matrix, to make it more obvious where to add/change the scala version in case of a bump. IMHO, we should add _all_ scala versions, to which we have a release for, to the test matrix.
