### PR TITLE
Fix REPL docs

### DIFF
--- a/amm/interp/api/src/main/scala/ammonite/interp/api/InterpAPI.scala
+++ b/amm/interp/api/src/main/scala/ammonite/interp/api/InterpAPI.scala
@@ -43,9 +43,7 @@ trait InterpAPI {
     * Functions that will be chained and called on the coursier
     * Fetch object right before they are run
     */
-  val resolutionHooks: mutable.Buffer[
-    Fetch => Fetch
-  ]
+  val resolutionHooks: mutable.Buffer[Fetch => Fetch]
 
   /**
     * Exit the Ammonite REPL. You can also use Ctrl-D to exit

--- a/amm/repl/api/src/main/scala/ammonite/repl/api/ReplAPI.scala
+++ b/amm/repl/api/src/main/scala/ammonite/repl/api/ReplAPI.scala
@@ -10,13 +10,12 @@ import scala.reflect.runtime.universe._
 
 trait ReplAPI {
 
-
-
   /**
    * Read/writable prompt for the shell. Use this to change the
    * REPL prompt at any time!
    */
   val prompt: Ref[String]
+
   /**
    * The front-end REPL used to take user input. Modifiable!
    */
@@ -36,6 +35,7 @@ trait ReplAPI {
     * when a Ctrl-C interrupt happened) via `lastException.printStackTrace`.
     */
   def lastException: Throwable
+
   /**
    * History of commands that have been entered into the shell, including
    * previous sessions
@@ -116,22 +116,24 @@ trait ReplAPI {
    * Current width of the terminal
    */
   def width: Int
+
   /**
    * Current height of the terminal
    */
   def height: Int
 
   def show(t: Any): Unit
+
   /**
    * Lets you configure the pretty-printing of a value. By default, it simply
    * disables truncation and prints the entire thing, but you can set other
    * parameters as well if you want.
    */
-
   def show(t: Any,
            width: Integer = null,
            height: Integer = null,
            indent: Integer = null): Unit
+
   /**
     * Functions that can be used to manipulate the current REPL session:
     * check-pointing progress, reverting to earlier checkpoints, or deleting
@@ -155,7 +157,9 @@ trait ReplAPI {
 
   def _compilerManager: ammonite.compiler.iface.CompilerLifecycleManager
 }
+
 trait ReplLoad{
+
   /**
     * Loads a command into the REPL and
     * evaluates them one after another
@@ -168,13 +172,15 @@ trait ReplLoad{
     * If an error happens it prints an error message to the console.
     */
   def exec(path: os.Path): Unit
-
 }
+
 trait Session{
+
   /**
     * The current stack of frames
     */
   def frames: List[Frame]
+
   /**
     * Checkpoints your current work, placing all future work into its own
     * frames. If a name is provided, it can be used to quickly recover
@@ -194,19 +200,23 @@ trait Session{
     * you to that many savepoints since the last one.
     */
   def pop(num: Int = 1): SessionChanged
+
   /**
     * Deletes a named checkpoint, allowing it to be garbage collected if it
     * is no longer accessible.
     */
   def delete(name: String): Unit
 }
+
 trait Clipboard{
+
   /**
     * Reads contents from the system clipboard.
     * @return System clipboard contents if they are readable as `String`,
     *         empty string otherwise.
     */
   def read: String
+  
   /**
     * Sets the contents of the system clipboard.
     *

--- a/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -292,10 +292,10 @@ object AdvancedTests extends TestSuite{
       }
     }
     test("compilerPlugin") - retry(3){
-      if (scala2_11) check.session("""
+      check.session("""
         @ // Compiler plugins imported without `.$plugin` are not loaded
 
-        @ import $ivy.`org.spire-math::kind-projector:0.6.3`
+        @ import $ivy.`org.typelevel::kind-projector:0.10.3`
 
         @ trait TC0[F[_]]
         defined trait TC0
@@ -305,7 +305,7 @@ object AdvancedTests extends TestSuite{
 
         @ // You need to use `import $plugin.$ivy`
 
-        @ import $plugin.$ivy.`org.spire-math::kind-projector:0.6.3`
+        @ import $plugin.$ivy.`org.typelevel::kind-projector:0.10.3`
 
         @ trait TC[F[_]]
         defined trait TC

--- a/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
@@ -71,7 +71,7 @@ object ProjectTests extends TestSuite{
               error: Failed to resolve ivy dependencies
 
               @ interp.repositories() ++= Seq(coursierapi.IvyRepository.of(
-              @    "https://repo.typesafe.com/typesafe/ivy-releases/[defaultPattern]"
+              @   "https://repo.typesafe.com/typesafe/ivy-releases/[defaultPattern]"
               @ ))
 
               @ import $ivy.`com.lightbend::emoji:1.2.1`

--- a/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
@@ -66,17 +66,17 @@ object ProjectTests extends TestSuite{
         test("resolvers"){
           retry(2){
             // ivy flakyness...
-            if (scala2_11) check.session("""
-              @ import $ivy.`com.ambiata::mundane:1.2.1-20141230225616-50fc792`
+            check.session("""
+              @ import $ivy.`com.lightbend::emoji:1.2.1`
               error: Failed to resolve ivy dependencies
 
               @ interp.repositories() ++= Seq(coursierapi.IvyRepository.of(
-              @   "https://ambiata-oss.s3-ap-southeast-2.amazonaws.com/[defaultPattern]"
+              @    "https://repo.typesafe.com/typesafe/ivy-releases/[defaultPattern]"
               @ ))
 
-              @ import $ivy.`com.ambiata::mundane:1.2.1-20141230225616-50fc792`
+              @ import $ivy.`com.lightbend::emoji:1.2.1`
 
-              @ import com.ambiata.mundane._
+              @ import com.lightbend.emoji._
             """)
           }
         }
@@ -177,8 +177,8 @@ object ProjectTests extends TestSuite{
 
     test("finagle"){
       // Prevent regressions when wildcard-importing things called `macro` or `_`
-      if (scala2_11) check.session("""
-        @ import $ivy.`com.twitter::finagle-httpx:6.26.0`
+      check.session("""
+        @ import $ivy.`com.twitter::finagle-http:21.2.0`
 
         @ import com.twitter.finagle._, com.twitter.util._
 
@@ -186,27 +186,27 @@ object ProjectTests extends TestSuite{
 
         @ var clientResponse = 0
 
-        @ val service = new Service[httpx.Request, httpx.Response] {
-        @   def apply(req: httpx.Request): Future[httpx.Response] = {
+        @ val service = new Service[http.Request, http.Response] {
+        @   def apply(req: http.Request): Future[http.Response] = {
         @     serverCount += 1
         @     Future.value(
-        @       httpx.Response(req.version, httpx.Status.Ok)
+        @       http.Response(req.version, http.Status.Ok)
         @     )
         @   }
         @ }
 
-        @ val server = Httpx.serve(":8080", service)
+        @ val server = Http.serve(":8080", service)
 
-        @ val client: Service[httpx.Request, httpx.Response] = Httpx.newService(":8080")
+        @ val client: Service[http.Request, http.Response] = Http.client.newService(":8080")
 
-        @ val request = httpx.Request(httpx.Method.Get, "/")
+        @ val request = http.Request(http.Method.Get, "/")
 
         @ request.host = "www.scala-lang.org"
 
-        @ val response: Future[httpx.Response] = client(request)
+        @ val response: Future[http.Response] = client(request)
 
-        @ response.onSuccess { resp: httpx.Response =>
-        @   clientResponse = resp.getStatusCode
+        @ response.onSuccess { resp: http.Response =>
+        @   clientResponse = resp.statusCode
         @ }
 
         @ Await.ready(response)

--- a/readme/Repl.scalatex
+++ b/readme/Repl.scalatex
@@ -19,7 +19,7 @@
 @sect("Ammonite-REPL", "A Modernized Scala REPL")
 
   @p
-    The @b{Ammonite-REPL} is an improved Scala REPL, re-implemented from first
+    The @b{Ammonite-REPL} is an improved Scala REPL, reimplemented from first
     principles. It is much more featureful than the default REPL and comes
     with a lot of @sect.ref("Features", "ergonomic improvements") and
     @sect.ref("Configuration", "configurability") that may be familiar to
@@ -28,9 +28,9 @@
 
   @p
     It can be combined with @sect.ref{Ammonite-Ops} to replace Bash as your
-    systems shell, but also can be used alone as a @sect.ref("Features",
-    "superior") version of the default Scala REPL, or as a
-    @sect.ref("Debugging", "debugging tool"), or for many other
+    systems shell, but can also be used alone as a @sect.ref("Features",
+    "superior") version of the default Scala REPL, as a
+    @sect.ref("Debugging", "debugging tool"), and for many other
     @sect.ref("Ammonite Cookbook", "fun and interesting things")!
 
 
@@ -68,11 +68,12 @@
 
   @sect{Installation on Windows}
     @p
-      Download the @lnk("Latest version", "https://github.com/com-lihaoyi/Ammonite/releases/download/@ammonite.Constants.version/2.13-@ammonite.Constants.version")
+      Download the @lnk("Latest version", s"https://github.com/com-lihaoyi/Ammonite/releases/download/${ammonite.Constants.version}/2.13-${ammonite.Constants.version}")
       and rename it to @code{amm.bat}
-  
-  @p
-    You can then run Ammonite via the `./amm` command.
+
+  @sect{Running Ammonite REPL}
+    @p
+      You can then run Ammonite via the `./amm` command.
 
   @p
     This will give you access to the Ammonite-REPL:
@@ -142,13 +143,12 @@
     sbt projectName/test:runMain amm
 
   @p
-    To activate the Ammonite REPL
+    to activate the Ammonite REPL.
 
   @p
     You can also pass a string to the @code{Main} call containing any
     commands or imports you want executed at the start of every run, along
-    with @lnk("other configuration",
-    "http://www.lihaoyi.com/Ammonite/api/repl/index.html#ammonite.Main").
+    with @lnk("other configuration", "#ammonite.Main").
     If you want Ammonite to be available in all projects, simply add the
     above snippet to a new file @code{~/.sbt/0.13/global.sbt}.
 
@@ -167,7 +167,7 @@
         By default, Ammonite @sect.ref("Configurable Truncation", "truncates")
         the pretty-printed output to avoid flooding your terminal. If you want
         to disable truncation, call @hl.scala{show(...)} on your expression to
-        pretty-print it's full output. You can also pass in an optional
+        pretty-print its full output. You can also pass in an optional
         @hl.scala{height = ...} parameter to control how much you want to show
         before truncation.
 
@@ -202,8 +202,8 @@
 
         @p
           You can use the @b{Up} and @b{Down} arrows to navigate between lines
-          within your snippet. @code{Enter} only executes the code when you're
-          on the last line of a multi-line snippet, meaning you can take your
+          within your snippet. @code{Enter} executes the code @i{only when you're
+          on the last line} of a multi-line snippet, meaning you can take your
           time, space out your code nicely, and fix any mistakes anywhere in your
           snippet. History is multi-line too, meaning re-running a multi-line
           snippet is trivial, even with tweaks.
@@ -423,14 +423,14 @@
 
       @sect{import $exec}
         @p
-          This is similar to @hl.scala{import $file}, except that it dumps the
-          definitions and imports from the script into your REPL session. This is
+          This is similar to @hl.scala{import $file}, except that it @i{dumps the
+          definitions and imports from the script} into your REPL session. This is
           useful if you are using a script to hold a set of common imports:
           using @sect.ref{import $file} to import a script doesn't propagate
           imports from that script into your REPL.
 
         @p
-          Alternatively, this is also useful if you want to split up your
+          It is also useful if you want to split up your
           @code{~/.ammonite/predef.sc} file into multiple scripts: e.g. if you
           want to break up your @code{predef.sc} into two scripts
           @code{~/.ammonite/predef.sc} and @code{~/.ammonite/helper.sc}. While
@@ -452,7 +452,11 @@
           For example, here is loading @lnk("Scalaz",
           "https://github.com/scalaz/scalaz") and using it in the Ammonite-REPL:
 
-        @hl.ref(ammoniteTests/"ProjectTests.scala", Seq("""test("scalaz")""", "@"))
+        @hl.scala
+          @@ import $ivy.`org.scalaz::scalaz-core:7.2.27`, scalaz._, Scalaz._
+
+          @@ (Option(1) |@{"@"}| Option(2))(_ + _)
+          res1: Option[Int] = Some(value = 3)
 
         @p
           Note that the different portions of the @hl.scala{$ivy} import are
@@ -786,13 +790,11 @@
             of implicit parameters, implicit conversions, macros, and other odd
             Scala features, @hl.scala{desugar} could you see what is left after
             all the magic happens.
-          @p
-            @hl.scala{desugar} only works in Scala 2.11.x and above, not in 2.10.x
 
     @sect{Save/Load Session}
       @p
         Ammonite allows you to save your work half way through, letting you
-        discard and future changes and returning to the state of the world you
+        discard any future changes and returning to the state of the world you
         saved.
 
       @p
@@ -949,7 +951,8 @@
         @hl.scala{prompt} to always include your current working directory
 
       @hl.scala
-        repl.prompt.bind(wd.toString + "@@ ")
+        import ammonite.ops._
+        repl.prompt.bind(pwd.toString + " @ ")
 
       @p
         As is common practice in other shells. Further modifications to make it
@@ -1133,4 +1136,4 @@
         other necessary infrastructure to allow trusted parties SSH access to
         the relevant machines. Running on @code{localhost} lets you leverage
         that and gain all the same security properties without having to
-        re-implement them in Scala.
+        reimplement them in Scala.

--- a/readme/Repl.scalatex
+++ b/readme/Repl.scalatex
@@ -952,7 +952,7 @@
 
       @hl.scala
         import ammonite.ops._
-        repl.prompt.bind(pwd.toString + " @ ")
+        repl.prompt.bind(pwd.toString + " @@ ")
 
       @p
         As is common practice in other shells. Further modifications to make it


### PR DESCRIPTION
These are mostly cosmetic changes for easier reading.  
Some examples didn't even work on scala 2.12/2.13 so I updated them.

Closes #1158 

An aside:  
Should we drop everything referencing scala 2.11 ?  
Because Ammonite is released only for 2.12+ AFAIK.  
There are refs in tests, docs etc...