### PR TITLE
Bump uPickle to 1.4.0

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -109,7 +109,7 @@ object Deps {
   val sourcecode = ivy"com.lihaoyi::sourcecode:0.2.1"
   val sshdCore = ivy"org.apache.sshd:sshd-core:1.2.0"
   val trees = ivy"org.scalameta::trees:$scalametaVersion"
-  val upickle = ivy"com.lihaoyi::upickle:1.3.15"
+  val upickle = ivy"com.lihaoyi::upickle:1.4.0"
   val utest = ivy"com.lihaoyi::utest:0.7.3"
 }
 


### PR DESCRIPTION
1.3.14/13.15 are binary incompatible with previous versions, so I bumped the middle number. Better to make Ammonite depend on the new version and then bump it's number as well