### PR TITLE
Increase release timeouts to 10 minutes

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -959,8 +959,8 @@ def publishSonatype(publishArtifacts: mill.main.Tasks[PublishModule.PublishData]
         sys.env("SONATYPE_DEPLOY_USER") + ":" + sys.env("SONATYPE_DEPLOY_PASSWORD"),
         true,
         Seq("--passphrase", sys.env("SONATYPE_PGP_PASSWORD"), "--no-tty", "--pinentry-mode", "loopback", "--batch", "--yes", "-a", "-b"),
-        120000,
-        120000,
+        600000,
+        600000,
         T.ctx().log,
         120000,
       ).publishAll(


### PR DESCRIPTION
This value has been working fine on some of my personal biggest mill projects (coursier, almond). Right now, the mill release jobs fail almost all the time on master.