### PR TITLE
Fix documentation rendering (`@compare`,` ammSample` bugs)

### DIFF
--- a/readme/Shell.scalatex
+++ b/readme/Shell.scalatex
@@ -139,7 +139,7 @@
         Here is how to find the largest 3 files in a given directory tree:
 
       @compare(
-        "find ./repl/src -ls | sort -nrk 7 | head -3",
+        "find ./amm/src -ls | sort -nrk 7 | head -3",
         "ls.rec! wd/'amm/'src | (x => x.size -> x.last) sortBy (-_._1) take 3"
       )
 


### PR DESCRIPTION
There were some bugs in `Sample.scala` which were truncating the script results, adding `$ bash` to every line of bash output and a typo (wrong directory name) in `Shell.scalatex` which caused a bash command to fail. These errors have made it challenging for those learning Ammonite via the documentation at https://ammonite.io/, as numerous inline examples were missing (not rendered).

This PR addresses the rendering problems for `@compare` and `ammSample`, which were reported in the following issues:
Fixes: https://github.com/com-lihaoyi/Ammonite/issues/1203, fixes: https://github.com/com-lihaoyi/Ammonite/issues/1102, fixes: https://github.com/com-lihaoyi/Ammonite/issues/1086, fixes: https://github.com/com-lihaoyi/Ammonite/issues/1132.

I am new to Ammonite and found it difficult to follow the documentation due to the rendering issues, so I hope this alleviates that problem for the issue openers and myself!

Additionally, I opened #1204, which I discovered while trying to fix the rendering issues. Looking through the `publishDocs` github action output will show other errors.

---

I went about my testing via the `publishDocs` github action, by printing out the raw html generated in `Sample.scala`. I wasn't sure how to build the docs locally, so this was my workaround 😅 

Here's the diff showing that some of the content was not getting rendered at all, and now we do have divs with the expected content: [html_diff.txt](https://github.com/com-lihaoyi/Ammonite/files/6985933/html_diff.txt) (rename to `html_diff.diff`)
And the html output that the diff was generated from: 
[current.txt](https://github.com/com-lihaoyi/Ammonite/files/6985934/current.txt) (rename to `current.html`), [fixes.txt](https://github.com/com-lihaoyi/Ammonite/files/6985935/fixes.txt) (rename to `fixes.html`).