### PR TITLE
Add option to enable ScalaPy in the REPL

### DIFF
--- a/amm/repl/src/main/scala/ammonite/main/Defaults.scala
+++ b/amm/repl/src/main/scala/ammonite/main/Defaults.scala
@@ -29,6 +29,17 @@ object Defaults{
       typeOf
     }""")
   )
+
+  val scalapyImports = Imports(
+    ImportData("""me.shadaj.scalapy.{
+      py
+    }"""),
+    ImportData("""me.shadaj.scalapy.py.{
+      PyQuote,
+      SeqConverters
+    }""")
+  )
+
   def ammoniteHome = os.Path(System.getProperty("user.home"))/".ammonite"
 
   def alreadyLoadedDependencies(

--- a/amm/src/main/scala/ammonite/main/Config.scala
+++ b/amm/src/main/scala/ammonite/main/Config.scala
@@ -89,7 +89,18 @@ object Config{
       doc =
         "Wrap user code in classes rather than singletons, typically for Java serialization "+
         "friendliness.")
-    classBased: Flag
+    classBased: Flag,
+    @arg(
+      name = "scalapy",
+      doc =
+        "Enable Scalapy")
+    scalapy: Flag,
+    @arg(
+      name = "python-executable",
+      doc =
+        """Path to the Python interpreter executable to be used with ScalaPy"""
+    )
+    pythonExecutable: Option[String]
   )
   implicit val replParser = ParserForClass[Repl]
 

--- a/build.sc
+++ b/build.sc
@@ -76,6 +76,7 @@ val (buildVersion, unstable) = scala.util.Try(
 val bspVersion = "2.0.0-M6"
 val fastparseVersion = "2.3.0"
 val scalametaVersion = "4.4.24"
+val scalapyVersion = "0.5.0"
 
 object Deps {
   val acyclic = ivy"com.lihaoyi::acyclic:0.2.0"
@@ -94,12 +95,14 @@ object Deps {
   val mainargs = ivy"com.lihaoyi::mainargs:0.2.0"
   val osLib = ivy"com.lihaoyi::os-lib:0.7.2"
   val pprint = ivy"com.lihaoyi::pprint:0.6.6"
+  val pythonNativeLibs = ivy"ai.kien::python-native-libs:0.2.1"
   val requests = ivy"com.lihaoyi::requests:0.6.5"
   val scalacheck = ivy"org.scalacheck::scalacheck:1.14.0"
   val scalaCollectionCompat = ivy"org.scala-lang.modules::scala-collection-compat:2.4.1"
   def scalaCompiler(scalaVersion: String) = ivy"org.scala-lang:scala-compiler:${scalaVersion}"
   val scalaJava8Compat = ivy"org.scala-lang.modules::scala-java8-compat:0.9.0"
   val scalaparse = ivy"com.lihaoyi::scalaparse:$fastparseVersion"
+  val scalapy = ivy"me.shadaj::scalapy-core:${scalapyVersion}"
   def scalaReflect(scalaVersion: String) = ivy"org.scala-lang:scala-reflect:${scalaVersion}"
   val scalaXml = ivy"org.scala-lang.modules::scala-xml:2.0.0-M3"
   val scalazCore = ivy"org.scalaz::scalaz-core:7.2.27"
@@ -397,7 +400,8 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
       def dependencyResourceFileName = "amm-interp-api-dependencies.txt"
       def ivyDeps = Agg(
         Deps.scalaReflect(scalaVersion()),
-        Deps.coursierInterface
+        Deps.coursierInterface,
+        Deps.pythonNativeLibs
       )
       def constantsFile = T {
         val dest = T.dest / "Constants.scala"
@@ -449,7 +453,7 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
       )
 
       def generatedSources = T{
-        Seq(PathRef(generateConstantsFile(buildVersion, bspVersion = bspVersion)))
+        Seq(PathRef(generateConstantsFile(buildVersion, bspVersion = bspVersion, scalapyVersion = scalapyVersion)))
       }
 
       def exposedClassPath = T{
@@ -750,6 +754,7 @@ def integrationTest(scalaVersion: String = sys.env("TRAVIS_SCALA_VERSION")) = T.
 def generateConstantsFile(version: String = buildVersion,
                           unstableVersion: String = "<fill-me-in-in-Constants.scala>",
                           bspVersion: String = "<fill-me-in-in-Constants.scala>",
+                          scalapyVersion: String = "<fill-me-in-in-Constants.scala>",
                           curlUrl: String = "<fill-me-in-in-Constants.scala>",
                           unstableCurlUrl: String = "<fill-me-in-in-Constants.scala>",
                           oldCurlUrls: Seq[(String, String)] = Nil,
@@ -761,6 +766,7 @@ def generateConstantsFile(version: String = buildVersion,
       val version = "$version"
       val unstableVersion = "$unstableVersion"
       val bspVersion = "$bspVersion"
+      val scalapyVersion = "$scalapyVersion"
       val curlUrl = "$curlUrl"
       val unstableCurlUrl = "$unstableCurlUrl"
       val oldCurlUrls = Seq[(String, String)](
@@ -898,6 +904,7 @@ def publishDocs() = {
       latestTaggedVersion,
       buildVersion,
       bspVersion,
+      scalapyVersion,
       s"https://github.com/${ghOrg}/${ghRepo}/releases/download/$stableKey",
       s"https://github.com/${ghOrg}/${ghRepo}/releases/download/$unstableKey",
       for(k <- oldStableKeys)
@@ -968,4 +975,3 @@ def publishSonatype(publishArtifacts: mill.main.Tasks[PublishModule.PublishData]
         x:_*
       )
   }
-


### PR DESCRIPTION
Add `--scalapy` flag that enables ScalaPy in the REPL by setting up the correct system properties required by ScalaPy, pre-importing ScalaPy Ivy dependency and the `py` object. The `--python-executable` allows optionally specifying the path to a specific Python interpreter executable to be used with ScalaPy (defaults to `python3` if not provided).

```sh
amm --scalapy
```

or

```sh
amm --scalapy --python-executable /usr/local/bin/python3.8
```

```scala
@ py"'Hello!'"
res0: py.Dynamic = Hello!

@ py"[x for x in ${List(1, 2, 3).toPythonProxy}]"
res1: py.Dynamic = [1, 2, 3]
```

Specifying `--amm --python-executable <path>` is equivalent to running

```scala
@
import $ivy.`ai.kien::python-native-libs:0.2.1`
import $ivy.`me.shadaj::scalapy-core:0.5.0`

ai.kien.python.Python("<path>").scalapyProperties.get.foreach {
  case (k, v) => System.setProperty(k, v)
}

import me.shadaj.scalapy.py
import me.shadaj.scalapy.py.{PyQuote, SeqConverters}
```

This adds no dependency to ammonite (not even scalapy) other than [python-native-libs](https://github.com/kiendang/python-native-libs), a tiny helper for calculating the correct system properties for ScalaPy to load a certain Python interpreter.

@alexarchambault