### PR TITLE
fix ImportData.ImportType use of sealed

### DIFF
--- a/amm/util/src/main/scala/ammonite/util/Imports.scala
+++ b/amm/util/src/main/scala/ammonite/util/Imports.scala
@@ -55,10 +55,18 @@ case class ImportData(fromName: Name,
 
 
 object ImportData{
-  sealed case class ImportType(name: String)
-  val Type = ImportType("Type")
-  val Term = ImportType("Term")
-  val TermType = ImportType("TermType")
+  sealed trait ImportType {
+    def name: String
+  }
+  case object Type extends ImportType {
+    def name = "Type"
+  }
+  case object Term extends ImportType {
+    def name = "Term"
+  }
+  case object TermType extends ImportType {
+    def name = "TermType"
+  }
 
   def apply(name: String, importType: ImportType = Term): Seq[ImportData] = {
     val elements = name.split('.')


### PR DESCRIPTION
The compiler says not all types are covered for this piece of code:
```scala
private[this] def onImportData(id: ImportData): Unit = {
  id.importType match {
    case ImportData.Type => onImportDataType(id)
    case ImportData.Term => onImportDataTerm(id)
    case ImportData.TermType =>
      onImportDataType(id)
      onImportDataTerm(id)
  }
}
```

I believe, that this is just simply from an incorrect usage of Scala's `sealed`.