### PR TITLE
Disambiguate compiler-interface module name

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -350,7 +350,10 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
   object compiler extends Cross[CompilerModule](fullCrossScalaVersions:_*) {
     object interface extends Cross[CompilerInterfaceModule](fullCrossScalaVersions:_*)
     class CompilerInterfaceModule(val crossScalaVersion: String) extends AmmModule{
-      def artifactName = "ammonite-compiler-interface"
+      def artifactName = T{
+        if (useCrossPrefix()) "ammonite-cross-23-compiler-interface"
+        else "ammonite-compiler-interface"
+      }
       def crossFullScalaVersion = true
       def moduleDeps = Seq(amm.util())
       def exposedClassPath = T{


### PR DESCRIPTION
It's compiled only in Scala 2, and used via dotty compat in Scala 3. For Scala 2, it depends on Scala 2 pprint. For Scala 3, it depends on Scala 3 pprint.

Without these changes, only the latter module ends up being published, which makes ammonite for 2.13.6 pull pprint for Scala 3 (along with pprint for Scala 2), which is a problem.

Also, the same module (`com.lihaoyi:ammonite-compiler-interface_2.13.6`) was built and published twice. A few commits ago, these were published in the same batch, so only one (apparently the latter) ended up actually published. Since two commits on master, these are published in separate batches, which makes one of them fail (because it tries to publish a module already published by the other batch).

With the changes here, we now publish `com.lihaoyi:ammonite-compiler-interface_2.13.6` (for Scala 2) and `com.lihaoyi:ammonite-cross-23-compiler-interface_2.13.6` (for Scala 3), which solves the ambiguity.

Fixes https://github.com/com-lihaoyi/Ammonite/issues/1214.

Fixes https://github.com/com-lihaoyi/Ammonite/issues/1197 (hopefully).