### PR TITLE
Update Scala to 2.12.15

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         java-version: [8, 11]
-        scala-version: [2.12.14, 2.13.6, 3.0.2]
+        scala-version: [2.12.15, 2.13.6, 3.0.2]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         java-version: [8, 11]
-        scala-version: [2.12.14, 2.13.6, 3.0.2]
+        scala-version: [2.12.15, 2.13.6, 3.0.2]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/build.sc
+++ b/build.sc
@@ -47,7 +47,7 @@ def withDottyCompat(dep: Dep, scalaVersion: String): Dep =
     case _ => dep
   }
 
-val scala2_12Versions = Seq("2.12.1", "2.12.2", "2.12.3", "2.12.4", "2.12.6", "2.12.7", "2.12.8", "2.12.9", "2.12.10", "2.12.11", "2.12.12", "2.12.13", "2.12.14")
+val scala2_12Versions = Seq("2.12.1", "2.12.2", "2.12.3", "2.12.4", "2.12.6", "2.12.7", "2.12.8", "2.12.9", "2.12.10", "2.12.11", "2.12.12", "2.12.13", "2.12.14", "2.12.15")
 val scala2_13Versions = Seq("2.13.0", "2.13.1", "2.13.2", "2.13.3", "2.13.4", "2.13.5", "2.13.6")
 val scala3Versions = Seq("3.0.0", "3.0.1", "3.0.2")
 
@@ -75,7 +75,7 @@ val (buildVersion, unstable) = scala.util.Try(
 
 val bspVersion = "2.0.0-M6"
 val fastparseVersion = "2.3.0"
-val scalametaVersion = "4.4.24"
+val scalametaVersion = "4.4.28"
 
 object Deps {
   val acyclic = ivy"com.lihaoyi::acyclic:0.2.0"


### PR DESCRIPTION
Requires https://github.com/scalameta/scalameta/pull/2474.