### PR TITLE
Issue #1148 trap exit when running script with --watch option

### DIFF
--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -358,6 +358,18 @@ object Main{
     */
   def isInteractive() = System.console() != null
 
+  def javaMajorVersion: Int = {
+    val prop = System.getProperty("java.version")
+    val prop0 =
+      if (prop.startsWith("1.")) prop.stripPrefix("1.")
+      else prop
+    val idx = prop0.indexOf('.')
+    val version =
+      if (idx < 0) prop0
+      else prop0.take(idx)
+    version.toInt
+  }
+
 
   class WhiteListClassLoader(whitelist: Set[Seq[String]], parent: ClassLoader)
     extends URLClassLoader(Array(), parent){
@@ -394,7 +406,7 @@ class MainRunner(cliConfig: Config,
                  wd: os.Path){
 
   // for trapping exit when the --watch option is on
-  if (cliConfig.core.watch.value)
+  if (cliConfig.core.watch.value && Main.javaMajorVersion < 17)
     System.setSecurityManager(TrapExitSecurityManager)
 
   val colors =

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -393,6 +393,10 @@ class MainRunner(cliConfig: Config,
                  stdErr: OutputStream,
                  wd: os.Path){
 
+  // for trapping exit when the --watch option is on
+  if (cliConfig.core.watch.value)
+    System.setSecurityManager(TrapExitSecurityManager)
+
   val colors =
     if(cliConfig.core.color.getOrElse(Main.isInteractive())) Colors.Default
     else Colors.BlackWhite

--- a/amm/src/main/scala/ammonite/main/TrapExitSecurityManager.scala
+++ b/amm/src/main/scala/ammonite/main/TrapExitSecurityManager.scala
@@ -1,0 +1,18 @@
+package ammonite.main
+import java.security.Permission
+
+/**
+ * This security manager is assigned as default one when we run user scripts with the --watch option
+ * This allows to trap sys.exit by throwing a special TrapExitException
+ */
+object TrapExitSecurityManager extends SecurityManager {
+
+  override def checkExit(status: Int): Unit = throw new TrapExitException(status)
+
+  override def checkPermission(perm: Permission): Unit = {}
+
+  private class TrapExitException(status: Int) extends RuntimeException {
+    override def toString: String = s"script exited with status $status"
+    override def getStackTrace: Array[StackTraceElement] = Array.empty
+  }
+}


### PR DESCRIPTION
When user runs the script with `--watch` option and if the script calls `sys.exit`, ammonite exits and doesn't stay in the watch loop. 
This PR adds a `TrapExitSecurityManager` that would be used when the `--watch` option is activated. When there is a `sys.exit` in the scrips, the special `TrapExitException` will be thrown giving a helpful output for the user:
<img width="610" alt="Screenshot 2021-10-20 at 14 45 53" src="https://user-images.githubusercontent.com/14926811/138097170-29e51330-0396-4681-9efc-27c170e88b0c.png">

Please let me know what you think 🙂 
