### PR TITLE
Fix handling of imports involving synthetic case class objects

### DIFF
--- a/amm/compiler/src/main/scala-2/ammonite/compiler/AmmonitePlugin.scala
+++ b/amm/compiler/src/main/scala-2/ammonite/compiler/AmmonitePlugin.scala
@@ -87,7 +87,6 @@ object AmmonitePlugin{
     def saneSym(sym: g.Symbol): Boolean = {
       !sym.name.decoded.contains('$') &&
       sym.exists &&
-      !sym.isSynthetic &&
       !sym.isPrivate &&
       !sym.isProtected &&
       sym.isPublic &&

--- a/amm/repl/src/test/scala/ammonite/session/ImportTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/ImportTests.scala
@@ -330,5 +330,25 @@ object ImportTests extends TestSuite{
         res3: Int = 1
       """)
     }
+    test("shapelessBugMinimized"){
+      check.session("""
+        @ object f{ case class Foo()}
+
+        @ import f.Foo
+
+        @ val Foo = 1
+
+        @ Foo
+      """)
+    }
+    test("shapelessBugFull"){
+      check.session("""
+        @ import $ivy.`com.chuusai::shapeless:2.3.2`, shapeless.::
+
+        @ implicit def :: = 1
+
+        @ ::
+      """)
+    }
   }
 }


### PR DESCRIPTION
Fixes #474

Turns out that even though the companion object for a `case class Foo` is marked as synthetic, it can still be imported and used. Thus when determining imports, we should not filter out synthetic symbols 