### PR TITLE
Use full file path for parse error messages and compiler metadata

### DIFF
--- a/amm/compiler/src/main/scala-2/ammonite/compiler/Compiler.scala
+++ b/amm/compiler/src/main/scala-2/ammonite/compiler/Compiler.scala
@@ -70,22 +70,11 @@ object Compiler{
 
   /**
     * Converts a bunch of bytes into Scalac's weird VirtualFile class
-    *
-    * Can only take in a relative path for the VirtualFile! Otherwise
-    * fails with a weird assert in the presentation compiler:
-    *
-    * [Current.sc]: exception during background compile:
-    * java.lang.AssertionError:
-    * assertion failed: (
-    *   ammonite/predef//Users/lihaoyi/Dropbox/Github/<-wrapped to next line->
-    *   Ammonite/target/tempAmmoniteHome/predef.sc,false,16,16)
-    *
-    * It appears that passing in the filename *only* results in the correct
-    * stack traces (e.g. Foo.sc:425 rather than Users/lihaoyi/Foo.sc:45), so we
-    * do that and assert to make sure it's only one path segment
     */
   def makeFile(src: Array[Byte], name: String) = {
-    val singleFile = new io.VirtualFile(name)
+    val segments = name.split("/", -1)
+
+    val singleFile = new io.VirtualFile(segments.last, segments.mkString("/"))
     val output = singleFile.output
     output.write(src)
     output.close()

--- a/amm/compiler/src/main/scala-3/ammonite/compiler/Compiler.scala
+++ b/amm/compiler/src/main/scala-3/ammonite/compiler/Compiler.scala
@@ -41,6 +41,7 @@ import dotty.tools.io.{
   ClassRepresentation,
   File,
   VirtualDirectory,
+  VirtualFile,
   PlainFile,
   Path
 }
@@ -215,8 +216,11 @@ class Compiler(
         val root = run.runContext.settings.sourceroot.value(using run.runContext)
         SourceFile(AbstractFile.getFile(Paths.get(root).resolve(fileName)), "UTF-8")
       }else{
+        val vf = new VirtualFile(fileName.split("/", -1).last, fileName){
+          override def jpath = java.nio.file.Paths.get(fileName)
+        }
         val chars = new String(src, StandardCharsets.UTF_8).toCharArray
-        new SourceFile(new PlainFile(Path(fileName)), chars)
+        new SourceFile(vf, chars)
       }
 
     implicit val ctx: Context = run.runContext.withSource(sourceFile)

--- a/amm/compiler/src/main/scala-3/ammonite/compiler/Compiler.scala
+++ b/amm/compiler/src/main/scala-3/ammonite/compiler/Compiler.scala
@@ -206,9 +206,15 @@ class Compiler(
         // semanticdb needs the sources to be written on disk, so we assume they're there already
         val root = run.runContext.settings.sourceroot.value(using run.runContext)
         SourceFile(AbstractFile.getFile(Paths.get(root).resolve(fileName)), "UTF-8")
-      } else
-        SourceFile.virtual(fileName, new String(src, StandardCharsets.UTF_8))
-
+      } else {
+        val chars =  new String (src, StandardCharsets.UTF_8).toCharArray
+        new SourceFile (AbstractFile.getFile (Paths.get(fileName)), chars)
+      }
+    System.err.println("sourceFile " + sourceFile)
+    System.err.println("sourceFile.path " + sourceFile.path)
+    System.err.println("sourceFile.name " + sourceFile.name)
+    System.err.println("sourceFile.file " + sourceFile.file)
+    System.err.println("sourceFile.getClass.getMethods " + sourceFile.getClass.getMethods.map(_.getName).toList)
     implicit val ctx: Context = run.runContext.withSource(sourceFile)
 
     val unit =

--- a/amm/compiler/src/main/scala-3/ammonite/compiler/Compiler.scala
+++ b/amm/compiler/src/main/scala-3/ammonite/compiler/Compiler.scala
@@ -35,7 +35,15 @@ import dotc.transform.{PostTyper, Staging}
 import dotc.typer.FrontEnd
 import dotc.util.{Property, SourceFile, SourcePosition}
 import dotc.util.Spans.Span
-import dotty.tools.io.{AbstractFile, ClassPath, ClassRepresentation, File, VirtualDirectory}
+import dotty.tools.io.{
+  AbstractFile,
+  ClassPath,
+  ClassRepresentation,
+  File,
+  VirtualDirectory,
+  PlainFile,
+  Path
+}
 import dotty.tools.repl.CollectTopLevelImports
 
 class Compiler(
@@ -206,15 +214,11 @@ class Compiler(
         // semanticdb needs the sources to be written on disk, so we assume they're there already
         val root = run.runContext.settings.sourceroot.value(using run.runContext)
         SourceFile(AbstractFile.getFile(Paths.get(root).resolve(fileName)), "UTF-8")
-      } else {
-        val chars =  new String (src, StandardCharsets.UTF_8).toCharArray
-        new SourceFile (AbstractFile.getFile (Paths.get(fileName)), chars)
+      }else{
+        val chars = new String(src, StandardCharsets.UTF_8).toCharArray
+        new SourceFile(new PlainFile(Path(fileName)), chars)
       }
-    System.err.println("sourceFile " + sourceFile)
-    System.err.println("sourceFile.path " + sourceFile.path)
-    System.err.println("sourceFile.name " + sourceFile.name)
-    System.err.println("sourceFile.file " + sourceFile.file)
-    System.err.println("sourceFile.getClass.getMethods " + sourceFile.getClass.getMethods.map(_.getName).toList)
+
     implicit val ctx: Context = run.runContext.withSource(sourceFile)
 
     val unit =

--- a/amm/compiler/src/main/scala-3/ammonite/compiler/Compiler.scala
+++ b/amm/compiler/src/main/scala-3/ammonite/compiler/Compiler.scala
@@ -216,11 +216,7 @@ class Compiler(
         val root = run.runContext.settings.sourceroot.value(using run.runContext)
         SourceFile(AbstractFile.getFile(Paths.get(root).resolve(fileName)), "UTF-8")
       }else{
-        val vf = new VirtualFile(fileName.split("/", -1).last, fileName){
-          override def jpath = java.nio.file.Paths.get(fileName)
-        }
-        val chars = new String(src, StandardCharsets.UTF_8).toCharArray
-        new SourceFile(vf, chars)
+        SourceFile.virtual(fileName, new String(src, StandardCharsets.UTF_8))
       }
 
     implicit val ctx: Context = run.runContext.withSource(sourceFile)

--- a/amm/compiler/src/main/scala-3/ammonite/compiler/Compiler.scala
+++ b/amm/compiler/src/main/scala-3/ammonite/compiler/Compiler.scala
@@ -216,7 +216,11 @@ class Compiler(
         val root = run.runContext.settings.sourceroot.value(using run.runContext)
         SourceFile(AbstractFile.getFile(Paths.get(root).resolve(fileName)), "UTF-8")
       }else{
-        SourceFile.virtual(fileName, new String(src, StandardCharsets.UTF_8))
+        val vf = new VirtualFile(fileName.split("/", -1).last, fileName)
+        val out = vf.output
+        out.write(src)
+        out.close()
+        new SourceFile(vf, scala.io.Codec.UTF8)
       }
 
     implicit val ctx: Context = run.runContext.withSource(sourceFile)

--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -328,7 +328,7 @@ class Interpreter(val compilerBuilder: CompilerBuilder,
       _ <- Catching{case e: Throwable => e.printStackTrace(); throw e}
       output <- Res(
         compilerManager.compileClass(
-          processed, printer, codeSource.fileName
+          processed, printer, codeSource.printablePath
         ),
         "Compilation Failed"
       )
@@ -388,7 +388,7 @@ class Interpreter(val compilerBuilder: CompilerBuilder,
         // another script which gets changed, and we'd only know when we reach that block
         lazy val splittedScript = parser.splitScript(
           Interpreter.skipSheBangLine(code),
-          codeSource.fileName
+          codeSource.printablePath
         )
 
         for{

--- a/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -431,34 +431,28 @@ object AdvancedTests extends TestSuite{
 
       val dir = os.pwd/'amm/'src/'test/'resources/'scripts/'predefWithLoad
       test("loadExec"){
-        if (scala2) {
-          val c1 = new DualTestRepl() {
-            override def predef = (
-              os.read(dir / "PredefLoadExec.sc"),
-              Some(dir / "PredefLoadExec.sc")
-            )
-          }
-          c1.session(
-            """
+        val c1 = new DualTestRepl() {
+          override def predef = (
+            os.read(dir/"PredefLoadExec.sc"),
+            Some(dir/"PredefLoadExec.sc")
+          )
+        }
+        c1.session("""
           @ val previouslyLoaded = predefDefinedValue
           previouslyLoaded: Int = 1337
         """)
-        }
       }
       test("loadModule"){
-        if (scala2) {
-          val c2 = new DualTestRepl() {
-            override def predef = (
-              os.read(dir / "PredefLoadModule.sc"),
-              Some(dir / "PredefLoadModule.sc")
-            )
-          }
-          c2.session(
-            """
+        val c2 = new DualTestRepl(){
+          override def predef = (
+            os.read(dir/"PredefLoadModule.sc"),
+            Some(dir/"PredefLoadModule.sc")
+          )
+        }
+        c2.session("""
           @ val previouslyLoaded = predefDefinedValue
           previouslyLoaded: Int = 1337
         """)
-        }
       }
       test("importIvy"){
         val c2 = new DualTestRepl(){

--- a/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -431,28 +431,34 @@ object AdvancedTests extends TestSuite{
 
       val dir = os.pwd/'amm/'src/'test/'resources/'scripts/'predefWithLoad
       test("loadExec"){
-        val c1 = new DualTestRepl() {
-          override def predef = (
-            os.read(dir/"PredefLoadExec.sc"),
-            Some(dir/"PredefLoadExec.sc")
-          )
-        }
-        c1.session("""
+        if (scala2) {
+          val c1 = new DualTestRepl() {
+            override def predef = (
+              os.read(dir / "PredefLoadExec.sc"),
+              Some(dir / "PredefLoadExec.sc")
+            )
+          }
+          c1.session(
+            """
           @ val previouslyLoaded = predefDefinedValue
           previouslyLoaded: Int = 1337
         """)
+        }
       }
       test("loadModule"){
-        val c2 = new DualTestRepl(){
-          override def predef = (
-            os.read(dir/"PredefLoadModule.sc"),
-            Some(dir/"PredefLoadModule.sc")
-          )
-        }
-        c2.session("""
+        if (scala2) {
+          val c2 = new DualTestRepl() {
+            override def predef = (
+              os.read(dir / "PredefLoadModule.sc"),
+              Some(dir / "PredefLoadModule.sc")
+            )
+          }
+          c2.session(
+            """
           @ val previouslyLoaded = predefDefinedValue
           previouslyLoaded: Int = 1337
         """)
+        }
       }
       test("importIvy"){
         val c2 = new DualTestRepl(){

--- a/amm/repl/src/test/scala/ammonite/session/FailureTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/FailureTests.scala
@@ -38,15 +38,11 @@ object FailureTests extends TestSuite{
           error: java is not a value
 
           @ 1 + vale
-          error: val res0 = 1 + vale
-                         ^^^^
-                         Not found: vale
+          error: Not found: vale
           Compilation Failed
 
           @ val x = 1 + vale
-          error: val x = 1 + vale
-                      ^^^^
-                      Not found: vale
+          error: Not found: vale
           Compilation Failed
         """)
     }

--- a/amm/src/test/resources/lineNumbers/sourceCodeMetadata.sc
+++ b/amm/src/test/resources/lineNumbers/sourceCodeMetadata.sc
@@ -1,0 +1,3 @@
+Console.err.println(sourcecode.FileName())
+Console.err.println(sourcecode.File())
+Console.err.println(sourcecode.Line())

--- a/amm/src/test/resources/lineNumbers/sourceCodeMetadata.sc
+++ b/amm/src/test/resources/lineNumbers/sourceCodeMetadata.sc
@@ -1,3 +1,3 @@
 Console.err.println(sourcecode.FileName())
 Console.err.println(sourcecode.File())
-Console.err.println(sourcecode.Line())
+//Console.err.println(sourcecode.Line()) doesn't work in scala 3

--- a/amm/src/test/scala/ammonite/interp/YRangeposTests.scala
+++ b/amm/src/test/scala/ammonite/interp/YRangeposTests.scala
@@ -10,7 +10,7 @@ object YRangeposTests extends TestSuite {
   val tests = Tests {
     println("YRangeposTests")
 
-    def checkErrorMessage(file: os.RelPath, expected: String): Unit = {
+    def checkErrorMessage(file: os.Path, expected: String): Unit = {
       val e = new InProcessMainMethodRunner(file, Nil, Nil)
 
       assert(e.err.contains(expected))
@@ -40,7 +40,7 @@ object YRangeposTests extends TestSuite {
       // behaviour, by checking that the line at which the error is found matches
       // the expected one in the file
       val expectedErrorMessage = "yRangeposError.sc:9: type mismatch;"
-      checkErrorMessage(os.rel / 'scriptCompilerSettings / "yRangeposError.sc",
+      checkErrorMessage(InProcessMainMethodRunner.base / 'scriptCompilerSettings / "yRangeposError.sc",
         expectedErrorMessage)
     }
     test("YrangeposError"){

--- a/amm/src/test/scala/ammonite/main/InProcessMainMethodRunner.scala
+++ b/amm/src/test/scala/ammonite/main/InProcessMainMethodRunner.scala
@@ -18,12 +18,12 @@ object InProcessMainMethodRunner{
   * JVM-level isolation between tests. But it works well enough for
   * our unit tests.
   */
-class InProcessMainMethodRunner(p: os.RelPath, preArgs: List[String], args: Seq[String]){
+class InProcessMainMethodRunner(p: os.Path, preArgs: List[String], args: Seq[String]){
 
   val in = new ByteArrayInputStream(Array.empty[Byte])
   val err0 = new ByteArrayOutputStream()
   val out0 = new ByteArrayOutputStream()
-  val path = InProcessMainMethodRunner.base/p
+  val path = p
 
 
   val success = Console.withIn(in){

--- a/amm/src/test/scala/ammonite/main/LineNumberTests.scala
+++ b/amm/src/test/scala/ammonite/main/LineNumberTests.scala
@@ -23,13 +23,15 @@ object LineNumberTests extends TestSuite{
     val isScala2 = sv.startsWith("2.")
 
     test("sourcecode"){
-      val path = InProcessMainMethodRunner.base / 'lineNumbers / "sourceCodeMetadata.sc"
-      checkErrorMessage(
-        file = path,
-        s"""sourceCodeMetadata.sc
-           |$path
-           |""".stripMargin
-      )
+      if (isScala2) {
+        val path = InProcessMainMethodRunner.base / 'lineNumbers / "sourceCodeMetadata.sc"
+        checkErrorMessage(
+          file = path,
+          s"""sourceCodeMetadata.sc
+             |$path
+             |""".stripMargin
+        )
+      }
     }
     //All Syntax Error tests currently don't pass on windows as fastparse gives out some 10
     //surrounding chars which are different on windows and linux due to `\n` and `\r\n`

--- a/amm/src/test/scala/ammonite/main/LineNumberTests.scala
+++ b/amm/src/test/scala/ammonite/main/LineNumberTests.scala
@@ -28,7 +28,6 @@ object LineNumberTests extends TestSuite{
         file = path,
         s"""sourceCodeMetadata.sc
            |$path
-           |3
            |""".stripMargin
       )
     }

--- a/amm/src/test/scala/ammonite/main/LineNumberTests.scala
+++ b/amm/src/test/scala/ammonite/main/LineNumberTests.scala
@@ -27,7 +27,7 @@ object LineNumberTests extends TestSuite{
       checkErrorMessage(
         file = path,
         s"""sourceCodeMetadata.sc
-           |/Users/lihaoyi/Github/Ammonite/amm/src/test/resources/lineNumbers/sourceCodeMetadata.sc
+           |$path
            |3
            |""".stripMargin
       )

--- a/amm/src/test/scala/ammonite/main/MainTests.scala
+++ b/amm/src/test/scala/ammonite/main/MainTests.scala
@@ -11,7 +11,7 @@ import utest._
  */
 class MainTests extends TestSuite{
   def exec(p: String, args: String*) =
-    new InProcessMainMethodRunner(os.rel / 'mains / p, Nil, args)
+    new InProcessMainMethodRunner(InProcessMainMethodRunner.base / 'mains / p, Nil, args)
 
   def stripInvisibleMargin(s: String): String = {
     val lines = Predef.augmentString(s).lines.toArray
@@ -40,7 +40,7 @@ class MainTests extends TestSuite{
     // logic revolves around handling arguments. Make sure this fails properly
     test("badAmmoniteFlag"){
       val evaled = new InProcessMainMethodRunner(
-        os.rel / 'mains/"Hello.sc",
+        InProcessMainMethodRunner.base / 'mains/"Hello.sc",
         List("--doesnt-exist"),
         Nil
       )

--- a/build.sc
+++ b/build.sc
@@ -300,7 +300,9 @@ class TerminalModule(val crossScalaVersion: String) extends AmmModule{
   else
     Agg(Deps.sourcecode)
 
-  object test extends Tests
+  object test extends Tests{
+    def ivyDeps = super.ivyDeps ++ Agg(Deps.sourcecode)
+  }
 }
 
 object amm extends Cross[MainModule](fullCrossScalaVersions:_*){

--- a/build.sc
+++ b/build.sc
@@ -513,6 +513,7 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
     def artifactName = "ammonite"
     def crossFullScalaVersion = true
     def mainClass = Some("ammonite.AmmoniteMain")
+    def ivyDeps = Agg(Deps.sourcecode)
     def moduleDeps = Seq(amm())
   }
 }

--- a/build.sc
+++ b/build.sc
@@ -301,7 +301,7 @@ class TerminalModule(val crossScalaVersion: String) extends AmmModule{
     Agg(Deps.sourcecode)
 
   object test extends Tests{
-    def ivyDeps = super.ivyDeps ++ Agg(Deps.sourcecode)
+    def ivyDeps = super.ivyDeps() ++ Agg(Deps.sourcecode)
   }
 }
 

--- a/build.sc
+++ b/build.sc
@@ -283,21 +283,22 @@ trait AmmDependenciesResourceFileModule extends JavaModule{
 object terminal extends Cross[TerminalModule](binCrossScalaVersions:_*)
 class TerminalModule(val crossScalaVersion: String) extends AmmModule{
   def ivyDeps = T{
-    val fansi =
-      if (scala3Versions.contains(crossScalaVersion))
-        Agg(
-          ivy"com.lihaoyi:fansi_3:${Deps.fansi.dep.version}",
-          ivy"org.scala-lang:scala3-library_3:$crossScalaVersion"
-        )
-      else
-        Agg(Deps.fansi)
-    fansi ++ Agg(
-      Deps.sourcecode
-    )
+    if (scala3Versions.contains(crossScalaVersion))
+      Agg(
+        ivy"com.lihaoyi:fansi_3:${Deps.fansi.dep.version}",
+        ivy"org.scala-lang:scala3-library_3:$crossScalaVersion",
+      )
+    else
+      Agg(Deps.fansi)
   }
   def compileIvyDeps = Agg(
+    Deps.sourcecode,
     Deps.scalaReflect(scalaVersion())
   )
+  def runIvyDeps = if (scala3Versions.contains(crossScalaVersion))
+    Agg(ivy"com.lihaoyi:sourcecode_3:${Deps.sourcecode.dep.version}")
+  else
+    Agg(Deps.sourcecode)
 
   object test extends Tests
 }
@@ -513,7 +514,6 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
     def artifactName = "ammonite"
     def crossFullScalaVersion = true
     def mainClass = Some("ammonite.AmmoniteMain")
-    def ivyDeps = Agg(Deps.sourcecode)
     def moduleDeps = Seq(amm())
   }
 }


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/Ammonite/issues/646
Fixes https://github.com/com-lihaoyi/Ammonite/issues/493

Previously we constructed a `new io.VirtualFile` with an identical name and path, both short, to ensure stack traces included only the file name. The correct thing to do is to provide separate names and paths, so stack traces can use the file name while compiler errors can use the full file path. This is done differently in Scala2 and Scala3 due to differences in the compiler APIs, but the end result is the same

This makes the parse/compile errors line up more with how the normal Scala compiler reports them, and fixes `sourcecode.File` to properly report the full path of the script file.

Updated the existing LineNumberTests to verify the fixed behavior, and added a new `sourceCodeMetadata.sc` test case to verify the fix applies to the `sourcecode.*` macros. For now `sourcecode.*` macros do not work in the REPL or scripts in Scala3, but that is an unrelated problem we can deal with later

Review by @alexarchambault  and @anatoliykmetyuk 

