### PR TITLE
Update Scala version to 2.13.8

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         java-version: [8, 11]
-        scala-version: [2.12.15, 2.13.7, 3.0.2]
+        scala-version: [2.12.15, 2.13.8, 3.0.2]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         java-version: [8, 11]
-        scala-version: [2.12.15, 2.13.7, 3.0.2]
+        scala-version: [2.12.15, 2.13.8, 3.0.2]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/build.sc
+++ b/build.sc
@@ -74,7 +74,7 @@ val (buildVersion, unstable) = scala.util.Try(
 
 val bspVersion = "2.0.0-M6"
 val fastparseVersion = "2.3.0"
-val scalametaVersion = "4.4.30"
+val scalametaVersion = "4.4.32"
 
 object Deps {
   val acyclic = ivy"com.lihaoyi:::acyclic:0.3.1"

--- a/build.sc
+++ b/build.sc
@@ -47,7 +47,7 @@ def withDottyCompat(dep: Dep, scalaVersion: String): Dep =
   }
 
 val scala2_12Versions = Seq("2.12.8", "2.12.9", "2.12.10", "2.12.11", "2.12.12", "2.12.13", "2.12.14", "2.12.15")
-val scala2_13Versions = Seq("2.13.0", "2.13.1", "2.13.2", "2.13.3", "2.13.4", "2.13.5", "2.13.6", "2.13.7")
+val scala2_13Versions = Seq("2.13.0", "2.13.1", "2.13.2", "2.13.3", "2.13.4", "2.13.5", "2.13.6", "2.13.7", "2.13.8")
 val scala3Versions = Seq("3.0.0", "3.0.1", "3.0.2")
 
 val binCrossScalaVersions = Seq(scala2_12Versions.last, scala2_13Versions.last, scala3Versions.last)
@@ -77,7 +77,7 @@ val fastparseVersion = "2.3.0"
 val scalametaVersion = "4.4.30"
 
 object Deps {
-  val acyclic = ivy"com.lihaoyi:::acyclic:0.3.0"
+  val acyclic = ivy"com.lihaoyi:::acyclic:0.3.1"
   val bsp4j = ivy"ch.epfl.scala:bsp4j:${bspVersion}"
   val bcprovJdk15on = ivy"org.bouncycastle:bcprov-jdk15on:1.56"
   val cask = ivy"com.lihaoyi::cask:0.6.0"


### PR DESCRIPTION
Also updated acyclic to 0.3.1 and scalameta to 4.4.32 for Scala 2.13.8 support.
