### PR TITLE
Re-added but deprecated old Main entry point

### DIFF
--- a/amm/src/main/scala/ammonite/AmmoniteMain.scala
+++ b/amm/src/main/scala/ammonite/AmmoniteMain.scala
@@ -20,7 +20,8 @@ import coursierapi.Dependency
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-
+// needed to support deprecated Main.main
+import acyclic.skipped
 
 object AmmoniteMain{
 

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -20,6 +20,8 @@ import coursierapi.Dependency
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
+// needed to support deprecated Main.main
+import acyclic.skipped
 
 
 /**

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -266,3 +266,7 @@ case class Main(predefCode: String = "",
   }
 }
 
+object Main {
+  @deprecated("Use ammonite.AmmoniteMain.main instead", "2.5.0")
+  def main(args: Array[String]): Unit = AmmoniteMain.main(args)
+}

--- a/amm/src/main/scala/ammonite/MainRunner.scala
+++ b/amm/src/main/scala/ammonite/MainRunner.scala
@@ -18,6 +18,8 @@ import scala.annotation.tailrec
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
+// needed to support deprecated Main.main
+import acyclic.skipped
 
 /**
   * Bundles together:


### PR DESCRIPTION
This avoids breaking when tools and scripts designed with Ammonite 2.4 and earlier try to start Ammonite.