### PR TITLE
Disambiguate cross Scala 2 / 3 artifact names more

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -153,7 +153,7 @@ trait AmmInternalModule extends CrossSbtModule{
     // ammonite-cross-23-… ones can depend on Scala 3 dependencies, even
     // though their JARs should be basically the same as their ammonite-…
     // counterparts.
-    val prefix = if (useCrossPrefix()) "ammonite-cross-23-" else "ammonite-"
+    val prefix = if (useCrossPrefix()) s"ammonite-cross-$crossScalaVersion-" else "ammonite-"
     prefix + millOuterCtx.segments.parts.mkString("-").stripPrefix("amm-")
   }
   def testFramework = "utest.runner.Framework"
@@ -357,7 +357,7 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
     object interface extends Cross[CompilerInterfaceModule](fullCrossScalaVersions:_*)
     class CompilerInterfaceModule(val crossScalaVersion: String) extends AmmModule{
       def artifactName = T{
-        if (useCrossPrefix()) "ammonite-cross-23-compiler-interface"
+        if (useCrossPrefix()) s"ammonite-cross-$crossScalaVersion-compiler-interface"
         else "ammonite-compiler-interface"
       }
       def crossFullScalaVersion = true
@@ -556,7 +556,7 @@ class MainModule(val crossScalaVersion: String)
 
   def artifactName = T{
     // See AmmInternalModule.artifactName for more details about ammonite-cross-23.
-    if (useCrossPrefix()) "ammonite-cross-23"
+    if (useCrossPrefix()) s"ammonite-cross-$crossScalaVersion"
     else "ammonite"
   }
 


### PR DESCRIPTION
Instead of publishing Scala 2 modules used by Scala 3 Ammonite with `ammonite-cross-23-`, like `ammonite-cross-23-interp-api_2.13.7`, this puts the target Scala 3 version in the prefix, like `ammonite-cross-3.1.0-interp-api_2.13.7`. That way, the modules originating from Scala `3.0.2` and `3.1.0` say, can't clash during the release stages of Ammonite.