### PR TITLE
Linux curl is scala 2.13

### DIFF
--- a/readme/Repl.scalatex
+++ b/readme/Repl.scalatex
@@ -36,7 +36,7 @@
   @sect{Installation on Linux}
     @p
       If you want to use Ammonite as a plain Scala shell, download the standalone
-      Ammonite @ammonite.Constants.version executable for Scala 2.12 (also
+      Ammonite @ammonite.Constants.version executable for Scala 2.13 (also
       available for @sect.ref{Older Scala Versions}):
 
     @hl.sh

--- a/readme/Scripts.scalatex
+++ b/readme/Scripts.scalatex
@@ -39,7 +39,7 @@
 
   @p
     To begin with, download the Ammonite @ammonite.Constants.version
-    script-runner for Scala 2.12 (also available for
+    script-runner for Scala 2.13 (also available for
     @sect.ref{Older Scala Versions}):
 
   @hl.sh


### PR DESCRIPTION
Was figuring out a local issue and noticed that this suggests the main Linux install is scala 2.12 when in fact it's a 2.13.

2.12 is referred to in the older scala versions section,