### PR TITLE
Add back positions in Scala 3 diagnostics

### DIFF
--- a/amm/compiler/src/main/scala-3/ammonite/compiler/Compiler.scala
+++ b/amm/compiler/src/main/scala-3/ammonite/compiler/Compiler.scala
@@ -13,7 +13,7 @@ import ammonite.compiler.iface.{
   _
 }
 import ammonite.compiler.internal.CompilerHelper
-import ammonite.util.{ImportData, Imports, Printer}
+import ammonite.util.{ImportData, Imports, PositionOffsetConversion, Printer}
 import ammonite.util.Util.newLine
 
 import dotty.tools.dotc
@@ -238,7 +238,38 @@ class Compiler(
 
     result match {
       case Left(errors) =>
+        val scalaPosToScPos = PositionOffsetConversion.scalaPosToScPos(
+          new String(src).drop(importsLen),
+          0,
+          0,
+          new String(src),
+          importsLen
+        )
+        val scFile = new SourceFile(sourceFile.file, sourceFile.content().drop(importsLen))
+        def scalaOffsetToScOffset(scalaOffset: Int): Option[Int] =
+          scalaPosToScPos(sourceFile.offsetToLine(scalaOffset), sourceFile.column(scalaOffset)).map {
+            case (scLine, scCol) => scFile.lineToOffset(scLine) + scCol
+          }
+        def scalaSpanToScSpan(scalaSpan: Span): Option[Span] =
+          for {
+            scStart <- scalaOffsetToScOffset(scalaSpan.start)
+            scEnd <- scalaOffsetToScOffset(scalaSpan.end)
+            scPoint <- scalaOffsetToScOffset(scalaSpan.point)
+          } yield Span(scStart, scEnd, scPoint)
+        def scalaSourcePosToScSourcePos(sourcePos: SourcePosition): Option[SourcePosition] =
+          if (sourcePos.source == sourceFile)
+            scalaSpanToScSpan(sourcePos.span).map { scSpan =>
+              SourcePosition(scFile, scSpan, sourcePos.outer)
+            }
+          else
+            None
+        def scalaDiagnosticToScDiagnostic(diag: reporting.Diagnostic): Option[reporting.Diagnostic] =
+          scalaSourcePosToScSourcePos(diag.pos).map { scPos =>
+            new reporting.Diagnostic(diag.msg, scPos, diag.level)
+          }
+
         errors
+          .map(d => scalaDiagnosticToScDiagnostic(d).getOrElse(d))
           .map(formatError)
           .map(_.msg.toString)
           .foreach(printer.error)
@@ -463,36 +494,5 @@ object Compiler:
 
   }
 
-  /** A `MessageRenderer` for the REPL without file positions */
   private[compiler] val messageRenderer =
-    new reporting.MessageRendering:
-      override def sourceLines(
-        pos: SourcePosition,
-        diagnosticLevel: String
-      )(using Context): (List[String], List[String], Int) = {
-        val (srcBefore, srcAfter, offset) = super.sourceLines(pos, diagnosticLevel)
-        val updatedSrcBefore = srcBefore.map { line =>
-          val chars = line.toCharArray
-          var i = 0
-          var updated = false
-          while (i < chars.length) {
-            if (chars(i) == '|')
-              i = chars.length
-             else if (chars(i).isDigit) {
-               chars(i) = ' '
-               updated = true
-             }
-            i += 1
-          }
-          if (updated) new String(chars)
-          else line
-        }
-        (updatedSrcBefore, srcAfter, offset)
-      }
-      // TODO Add this back for scripts
-      override def posStr(
-        pos: SourcePosition,
-        diagnosticLevel: String,
-        message: reporting.Message
-      )(using Context): String =
-        ""
+    new reporting.MessageRendering {}

--- a/amm/interp/src/main/scala/ammonite/interp/script/AmmoniteBuildServer.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/script/AmmoniteBuildServer.scala
@@ -11,7 +11,7 @@ import ammonite.compiler.iface.{CodeWrapper, CompilerBuilder, Parser}
 import ammonite.interp.api.InterpAPI
 import ammonite.interp.DependencyLoader
 import ammonite.runtime.{ImportHook, Storage}
-import ammonite.util.{Classpath, Imports, Printer}
+import ammonite.util.{Classpath, Imports, Position, PositionOffsetConversion, Printer}
 import ch.epfl.scala.bsp4j.{Diagnostic => BDiagnostic, Position => BPosition, _}
 import coursierapi.{Dependency, Repository}
 import org.eclipse.lsp4j.jsonrpc.Launcher

--- a/amm/interp/src/main/scala/ammonite/interp/script/Diagnostic.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/script/Diagnostic.scala
@@ -1,5 +1,7 @@
 package ammonite.interp.script
 
+import ammonite.util.Position
+
 final case class Diagnostic(
   severity: String,
   start: Position,

--- a/amm/interp/src/main/scala/ammonite/interp/script/ScriptProcessor.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/script/ScriptProcessor.scala
@@ -5,7 +5,7 @@ import java.io.File
 import ammonite.compiler.iface.{CodeWrapper, Parser}
 import ammonite.interp.{DependencyLoader, Interpreter}
 import ammonite.runtime.{Frame, ImportHook, Storage}
-import ammonite.util.{ImportTree, Name, Util}
+import ammonite.util.{ImportTree, Name, PositionOffsetConversion, Util}
 import ammonite.util.Util.CodeSource
 import coursierapi.{Dependency, Repository}
 

--- a/amm/interp/src/main/scala/ammonite/interp/script/SingleScriptCompiler.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/script/SingleScriptCompiler.scala
@@ -4,7 +4,7 @@ import ammonite.compiler.iface.{CodeWrapper, Compiler, CompilerBuilder}
 import ammonite.compiler.iface.Compiler.{Output => CompilerOutput}
 import ammonite.interp.Interpreter
 import ammonite.runtime.{Frame, Storage}
-import ammonite.util.{Classpath, Imports, Name, Printer, Res}
+import ammonite.util.{Classpath, Imports, Name, Position, PositionOffsetConversion, Printer, Res}
 
 import scala.collection.mutable
 

--- a/amm/src/test/scala/ammonite/main/LineNumberTests.scala
+++ b/amm/src/test/scala/ammonite/main/LineNumberTests.scala
@@ -48,10 +48,10 @@ object LineNumberTests extends TestSuite{
                 |                       ^""".stripMargin
             else
               s"""$path
-                |  |    printlnqs(unsorted))
+                |-- [E040] Syntax Error: <splitter>:5:23 ----------------------------------------
+                |5 |    printlnqs(unsorted))
                 |  |                       ^
-                |  |                       '}' expected, but ')' found
-                |""".stripMargin
+                |  |                       '}' expected, but ')' found""".stripMargin
           )
         )
       }
@@ -69,10 +69,10 @@ object LineNumberTests extends TestSuite{
                 |^""".stripMargin
             else
               s"""$path
-                |  |}
+                |-- [E040] Syntax Error: <splitter>:3:0 -----------------------------------------
+                |3 |}
                 |  |^
-                |  |eof expected, but '}' found
-                |""".stripMargin
+                |  |eof expected, but '}' found""".stripMargin
           )
         )
       }
@@ -91,10 +91,10 @@ object LineNumberTests extends TestSuite{
                 |^""".stripMargin
             else
               s"""$path
-                |  |}
+                |-- [E040] Syntax Error: <splitter>:3:0 -----------------------------------------
+                |3 |}
                 |  |^
-                |  |eof expected, but '}' found
-                |""".stripMargin
+                |  |eof expected, but '}' found""".stripMargin
           )
         )
       }
@@ -112,9 +112,11 @@ object LineNumberTests extends TestSuite{
           else {
             val firstLine = "quicort(unsorted.filter(_ < pivot)):::List(pivot):::" +
               "quicksort(unsorted.filter(_ > pivot))"
-            s"""|   |    $firstLine
-                |   |    ^^^^^^^
-                |   |    Not found: quicort""".stripMargin
+            val sp = " "
+            s"""-- [E006] Not Found Error: $path:7:4$sp
+               |7 |    $firstLine
+               |  |    ^^^^^^^
+               |  |    Not found: quicort""".stripMargin
           }
         )
       )
@@ -129,10 +131,13 @@ object LineNumberTests extends TestSuite{
             s"""$path:14: not found: value printnl
               |val res_0 = printnl("OK")
               |            ^""".stripMargin
-          else
-            """   |val res_0 = printnl("OK")
-              |   |            ^^^^^^^
-              |   |            Not found: printnl""".stripMargin
+          else {
+            val sp = " "
+            s"""-- [E006] Not Found Error: $path:1:12$sp
+               |1 |val res_0 = printnl("OK")
+               |  |            ^^^^^^^
+               |  |            Not found: printnl""".stripMargin
+          }
         )
       )
     }
@@ -146,10 +151,13 @@ object LineNumberTests extends TestSuite{
             s"""$path:30: not found: value prinntl
               |val res = prinntl("Ammonite")
               |          ^""".stripMargin
-          else
-            """   |val res = prinntl("Ammonite")
-              |   |          ^^^^^^^
-              |   |          Not found: prinntl""".stripMargin
+          else {
+            val sp = " "
+            s"""-- [E006] Not Found Error: $path:3:10$sp
+               |3 |val res = prinntl("Ammonite")
+               |  |          ^^^^^^^
+               |  |          Not found: prinntl""".stripMargin
+          }
         )
       )
     }
@@ -175,10 +183,13 @@ object LineNumberTests extends TestSuite{
             s"""$path:7: not found: value noSuchObject
               |  val x = noSuchObject.badFunction
               |          ^""".stripMargin
-          else
-            """   |  val x = noSuchObject.badFunction
-              |   |          ^^^^^^^^^^^^
-              |   |          Not found: noSuchObject""".stripMargin
+          else {
+            val sp = " "
+            s"""-- [E006] Not Found Error: $path:7:10$sp
+               |7 |  val x = noSuchObject.badFunction
+               |  |          ^^^^^^^^^^^^
+               |  |          Not found: noSuchObject""".stripMargin
+          }
         )
       )
     }

--- a/amm/util/src/main/scala/ammonite/util/Position.scala
+++ b/amm/util/src/main/scala/ammonite/util/Position.scala
@@ -1,3 +1,3 @@
-package ammonite.interp.script
+package ammonite.util
 
 final case class Position(line: Int, char: Int)

--- a/amm/util/src/main/scala/ammonite/util/PositionOffsetConversion.scala
+++ b/amm/util/src/main/scala/ammonite/util/PositionOffsetConversion.scala
@@ -1,4 +1,4 @@
-package ammonite.interp.script
+package ammonite.util
 
 import scala.collection.mutable
 

--- a/build.sc
+++ b/build.sc
@@ -1,7 +1,9 @@
 import mill._, scalalib._, publish._
+import mill.contrib.bloop.Bloop
 import coursier.mavenRepositoryString
 import $file.ci.upload
 
+import $ivy.`com.lihaoyi::mill-contrib-bloop:$MILL_VERSION`
 import $ivy.`io.get-coursier::coursier-launcher:2.0.0-RC6-10`
 
 val ghOrg = "com-lihaoyi"
@@ -142,7 +144,10 @@ trait CrossSbtModule extends mill.scalalib.SbtModule with mill.scalalib.CrossMod
   }
 }
 
-trait AmmInternalModule extends CrossSbtModule{
+trait AmmInternalModule extends CrossSbtModule with Bloop.Module{
+  def skipBloop =
+    // no need to expose the modules for old Scala versions support in Bloop / Metals
+    !binCrossScalaVersions.contains(crossScalaVersion)
   def useCrossPrefix = T{
     scala3Versions.contains(crossScalaVersion) && !scala3Versions.contains(scalaVersion())
   }

--- a/integration/src/test/scala/ammonite/integration/ErrorTruncationTests.scala
+++ b/integration/src/test/scala/ammonite/integration/ErrorTruncationTests.scala
@@ -26,38 +26,48 @@ object ErrorTruncationTests extends TestSuite{
   }
   val tests = Tests {
     println("ErrorTruncationTests")
-    test("compileError") - checkErrorMessage(
-      file = os.rel/'errorTruncation/"compileError.sc",
-      expected = Util.normalizeNewlines(
-        if (isScala2)
-          s"""compileError.sc:1: not found: value doesntexist
-            |val res = doesntexist
-            |          ^
-            |Compilation Failed
-            |""".stripMargin
-        else
-          s"""|   |val res = doesntexist
-              |   |          ^^^^^^^^^^^
-              |   |          Not found: doesntexist
-              |Compilation Failed""".stripMargin
+    test("compileError") {
+      val path = os.rel/'errorTruncation/"compileError.sc"
+      val sp = " "
+      checkErrorMessage(
+        file = path,
+        expected = Util.normalizeNewlines(
+          if (isScala2)
+            s"""compileError.sc:1: not found: value doesntexist
+               |val res = doesntexist
+               |          ^
+               |Compilation Failed
+               |""".stripMargin
+          else
+            s"""-- [E006] Not Found Error: ${replStandaloneResources / path}:1:10$sp
+               |1 |val res = doesntexist
+               |  |          ^^^^^^^^^^^
+               |  |          Not found: doesntexist
+               |Compilation Failed""".stripMargin
+        )
       )
-    )
-    test("multiExpressionError") - checkErrorMessage(
-      file = os.rel / 'errorTruncation/"compileErrorMultiExpr.sc",
-      expected = Util.normalizeNewlines(
-        if (isScala2)
-          s"""compileErrorMultiExpr.sc:11: not found: value doesntexist
-            |val res_4 = doesntexist
-            |            ^
-            |Compilation Failed
-            |""".stripMargin
-        else
-          s"""|   |val res_4 = doesntexist
-              |   |            ^^^^^^^^^^^
-              |   |            Not found: doesntexist
-              |Compilation Failed""".stripMargin
+    }
+    test("multiExpressionError") {
+      val path = os.rel / 'errorTruncation/"compileErrorMultiExpr.sc"
+      val sp = " "
+      checkErrorMessage(
+        file = path,
+        expected = Util.normalizeNewlines(
+          if (isScala2)
+            s"""compileErrorMultiExpr.sc:11: not found: value doesntexist
+               |val res_4 = doesntexist
+               |            ^
+               |Compilation Failed
+               |""".stripMargin
+          else
+            s"""-- [E006] Not Found Error: ${replStandaloneResources / path}:11:12$sp
+               |11 |val res_4 = doesntexist
+               |   |            ^^^^^^^^^^^
+               |   |            Not found: doesntexist
+               |Compilation Failed""".stripMargin
+        )
       )
-    )
+    }
 
     test("parseError"){
       if(!Util.windowsPlatform){
@@ -70,9 +80,10 @@ object ErrorTruncationTests extends TestSuite{
                 |^
                 |""".stripMargin
             else
-              """|  |}
-                 |  |^
-                 |  |eof expected, but '}' found""".stripMargin
+              """-- [E040] Syntax Error: <splitter>:1:0 -----------------------------------------
+                |1 |}
+                |  |^
+                |  |eof expected, but '}' found""".stripMargin
           )
         )
       }

--- a/integration/src/test/scala/ammonite/integration/LineNumberTests.scala
+++ b/integration/src/test/scala/ammonite/integration/LineNumberTests.scala
@@ -18,20 +18,25 @@ object LineNumberTests extends TestSuite{
     }
 
 
-    test("compilationErrorInSecondBlock") - checkErrorMessage(
-      file = os.rel/'lineNumbers/"compilationErrorInSecondBlock.sc",
-      expected = Util.normalizeNewlines(
-        if (isScala2)
-          """compilationErrorInSecondBlock.sc:14: not found: value printnl
-            |val res_0 = printnl("OK")
-            |            ^""".stripMargin
-        else
-          """|   |val res_0 = printnl("OK")
-             |   |            ^^^^^^^
-             |   |            Not found: printnl
-             |Compilation Failed""".stripMargin
+    test("compilationErrorInSecondBlock") {
+      val path = os.rel/'lineNumbers/"compilationErrorInSecondBlock.sc"
+      val sp = " "
+      checkErrorMessage(
+        file = path,
+        expected = Util.normalizeNewlines(
+          if (isScala2)
+            """compilationErrorInSecondBlock.sc:14: not found: value printnl
+              |val res_0 = printnl("OK")
+              |            ^""".stripMargin
+          else
+            s"""-- [E006] Not Found Error: ${replStandaloneResources / path}:1:12$sp
+               |1 |val res_0 = printnl("OK")
+               |  |            ^^^^^^^
+               |  |            Not found: printnl
+               |Compilation Failed""".stripMargin
+        )
       )
-    )
+    }
 
   }
 }


### PR DESCRIPTION
I didn't take the time to update positions in diagnostics returned by dotty, when adding Scala 3 support, so positions were stripped in Scala 3 diagnostics. This PR fixes that.

Before:
```text
   |  n azzd 3
   |  ^^^^^^
   |value azzd is not a member of Int, but could be made available as an extension method.
   |
   |The following import might make progress towards fixing the problem:
   |
   |  import sourcecode.Text.generate
   |
Compilation Failed
```

After:
```text
-- [E008] Not Found Error: cmd0.sc:3:4 -----------------------------------------
3 |  n azzd 3
  |  ^^^^^^
  |value azzd is not a member of Int, but could be made available as an extension method.
  |
  |The following import might make progress towards fixing the problem:
  |
  |  import sourcecode.Text.generate
  |
Compilation Failed
```