### PR TITLE
bugfix: Set proper Scala version in ScalaBuildTarget data

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/script/AmmoniteBuildServer.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/script/AmmoniteBuildServer.scala
@@ -175,8 +175,8 @@ class AmmoniteBuildServer(
   private def scriptBuildTarget(script: Script, path: os.Path): BuildTarget = {
     val scalaTarget = new ScalaBuildTarget(
       "org.scala-lang",
-      scala.util.Properties.versionNumberString,
-      scala.util.Properties.versionNumberString.split('.').take(2).mkString("."),
+      compiler.scalaVersion,
+      compiler.scalaVersion.split('.').take(2).mkString("."),
       ScalaPlatform.JVM,
       // TODO This seems not to matter as long as the scala-compiler JARs and all
       // are in the classpath we pass via ScalacOptions.

--- a/amm/interp/src/main/scala/ammonite/interp/script/ScriptCompiler.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/script/ScriptCompiler.scala
@@ -25,6 +25,8 @@ final class ScriptCompiler(
 
   import ScriptProcessor.SeqOps
 
+  def scalaVersion = compilerBuilder.scalaVersion
+
   /** Compiles a script, along with its dependencies */
   def compile(
     module: Script,

--- a/amm/src/test/scala/ammonite/interp/script/AmmoniteBuildServerTests.scala
+++ b/amm/src/test/scala/ammonite/interp/script/AmmoniteBuildServerTests.scala
@@ -759,11 +759,19 @@ object AmmoniteBuildServerTests extends TestSuite {
           val classPath = item.getClasspath.asScala.toList
           val classDir = os.Path(Paths.get(new URI(item.getClassDirectory)))
 
+          val targets = buildTargetsResp.getTargets()
+          assert(targets.asScala.nonEmpty)
+          val scalaTarget = targets.get(0).getData().asInstanceOf[ScalaBuildTarget]
+          
           if (isScala2) {
+            assert(scalaTarget.getScalaVersion().startsWith("2"))
+            assert(scalaTarget.getScalaBinaryVersion().startsWith("2"))
             assert(options.contains("-Yrangepos"))
             assert(options.exists(_.startsWith("-P:semanticdb:sourceroot:")))
             assert(options.exists(_.startsWith("-P:semanticdb:targetroot:")))
           } else {
+            assert(scalaTarget.getScalaVersion().startsWith("3"))
+            assert(scalaTarget.getScalaBinaryVersion().startsWith("3"))
             assert(options.contains("-Xsemanticdb") || options.contains("-Xsemanticdb"))
             assert(options.contains("-sourceroot"))
             assert(options.contains("-semanticdb-target"))


### PR DESCRIPTION
Previously, we would use the Scala version from the Scala library, which will be 2.13.8 even for Scala 3. Now we take the same version as the compiler.