### PR TITLE
[Scala3] support extension methods

### DIFF
--- a/amm/compiler/src/main/scala-3/ammonite/compiler/Preprocessor.scala
+++ b/amm/compiler/src/main/scala-3/ammonite/compiler/Preprocessor.scala
@@ -157,7 +157,11 @@ class Preprocessor(
       cond.lift(tree).map{ name =>
         val printer =
           if (isPrivate(tree)) Nil
-          else Seq(definedStr(definitionLabel, Name.backtickWrap(name.decode.toString)))
+          else
+            val definedName =
+              if name.isEmpty then ""
+              else Name.backtickWrap(name.decode.toString)
+            Seq(definedStr(definitionLabel, definedName))
         Expanded(
           code,
           printer
@@ -179,6 +183,10 @@ class Preprocessor(
       desugar.inventGivenOrExtensionName(m.tpt)
     case m: untpd.DefDef =>
       m.name
+  }
+
+  private val ExtDef = DefProc("extension methods") {
+    case ext: untpd.ExtMethods => Names.EmptyTermName
   }
   private val TypeDef = DefProc("type"){ case m: untpd.TypeDef => m.name }
 
@@ -254,7 +262,7 @@ class Preprocessor(
   }
 
   private val decls = Seq[(String, String, untpd.Tree) => Option[Expanded]](
-    ObjectDef, ClassDef, TraitDef, DefDef, TypeDef, VarDef, PatDef, Import, Expr
+    ObjectDef, ClassDef, TraitDef, DefDef, ExtDef, TypeDef, VarDef, PatDef, Import, Expr
   )
 
   private def complete(

--- a/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -621,5 +621,29 @@ object AdvancedTests extends TestSuite{
           fooOrd: Ordering[Foo] = <given>
         """)
     }
+    test("extension-methods"){
+      if (scala2) "N/A"
+      else
+        check.session("""
+          @ extension (x: Int) def incr = x + 1
+          defined extension methods
+
+          @ 1.incr
+          res1: Int = 2
+
+          @ {
+          @ extension (x: String)
+          @   def ident = x
+          @   def concat(other: String) = x ++ other
+          @ }
+          defined extension methods
+
+          @ "test".ident
+          res3: String = "test"
+
+          @ "test".concat("test")
+          res4: String = "testtest"
+        """)
+    }
   }
 }


### PR DESCRIPTION
fix: https://github.com/com-lihaoyi/Ammonite/issues/1281

Previously, ammonite REPL couldn't define extension methods
because of the lack of Preprocessor for extension method definition.

```
❯ scala-cli repl --scala 3.1.3 --ammonite
Loading...
Welcome to the Ammonite Repl 2.5.4-11-4f5bf2aa (Scala 3.1.3 Java 17.0.3)
@ extension (foo: Int)
    def bar = foo

-- [E006] Not Found Error: cmd0.sc:1:11 ----------------------------------------
1 |val res0 = extension (foo: Int)
  |           ^^^^^^^^^
  |           Not found: extension
  |
  | longer explanation available when compiling with `-explain`
-- [E006] Not Found Error: cmd0.sc:1:22 ----------------------------------------
1 |val res0 = extension (foo: Int)
  |                      ^^^
  |                      Not found: foo
  |
  | longer explanation available when compiling with `-explain`
-- [E006] Not Found Error: cmd0.sc:2:12 ----------------------------------------
2 |  def bar = foo
  |            ^^^
  |            Not found: foo
  |
  | longer explanation available when compiling with `-explain`
Compilation Failed
```

Now, this is possible to define extension methods in Ammonite REPL.

```
Welcome to the Ammonite Repl 2.5.4-14-dc4c47bc (Scala 3.1.3 Java 1.8.0_302)
@ extension (foo: Int)
    def x = 1
    def y = 1

defined extension methods

@ 100.x
res1: Int = 1
```