### PR TITLE
Fix source and browse utilities to be able to use out of the box

### DIFF
--- a/amm/compiler/src/main/scala-2/ammonite/compiler/tools/SourceRuntime.scala
+++ b/amm/compiler/src/main/scala-2/ammonite/compiler/tools/SourceRuntime.scala
@@ -12,6 +12,10 @@ import scala.language.experimental.macros
 
 object SourceRuntime{
 
+  def defaultPPrinter = pprint.PPrinter.Color.copy(defaultHeight = Int.MaxValue)
+
+  def browseSourceCommand(targetLine: Int) = Seq("less", "+" + targetLine,"-RMN")
+
   /**
     * Pull the height from the pretty-printer as a heuristic to shift the
     * desired line towards the middle of the screen. Typically, the

--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -733,7 +733,8 @@ object Interpreter{
     ImportData("ammonite.runtime.tools.tail", importType = ImportData.TermType),
     ImportData("ammonite.compiler.tools.{desugar, source}"),
     ImportData("mainargs.{arg, main}"),
-    ImportData("ammonite.repl.tools.Util.PathRead")
+    ImportData("ammonite.repl.tools.Util.PathRead"),
+    ImportData("ammonite.repl.ReplBridge.value.codeColorsImplicit")
   )
 
 

--- a/amm/repl/api/src/main/scala/ammonite/runtime/tools/Tools.scala
+++ b/amm/repl/api/src/main/scala/ammonite/runtime/tools/Tools.scala
@@ -221,7 +221,7 @@ object browse{
             width: Integer = null,
             height: Integer = 9999999,
             indent: Integer = null)
-           (implicit pp: pprint.PPrinter,
+           (implicit pp: pprint.PPrinter = pprint.PPrinter.Color.copy(defaultHeight = Int.MaxValue),
             wd: os.Path = os.pwd) = {
 
     os.proc(


### PR DESCRIPTION
fix https://github.com/com-lihaoyi/Ammonite/issues/1254

This PR enables Ammonite-REPL to use `browse` and `source` built-in utilities out of the box.

![ammonite-browse](https://user-images.githubusercontent.com/9353584/186577514-ae84ced5-3ab2-44a6-8a5b-d4e16df2119a.gif)

- `browse`
  - As @ches mentioned in https://github.com/com-lihaoyi/Ammonite/issues/1254, `browse` takes implicit `pprint.PPrinter` that is not in the REPL scope by default.
  - fixed by giving a default argument https://github.com/com-lihaoyi/Ammonite/commit/05e295855b79a2cd3e861a5b7c81553caa30678a
- `source`
  - define `browseSourceCommand` that is called from macro (looks like forgotten to port in https://github.com/com-lihaoyi/Ammonite/commit/ba57f10ab8ca1c5b8c1e2041c9c338d44d1cb885)
  - Added `repl.codeColorsImplicit` to `predefImport`, (is this ok?)
  - Add `pprint.PPrinter` as default parameters (in a wired way)
    - default argument doesn't work for macro definition
    - import implicit `pprint.PPrinter` to REPL scope may change the behavior of other commands (like `grep`, `browse`) because they also receive implicit `pprint.PPrinter` (but it would be better to use different printer instance?)