### PR TITLE
Autocomplete (some) ivy Imports when there is no Closing Backtick

### DIFF
--- a/amm/compiler/src/main/scala-2/ammonite/compiler/Pressy.scala
+++ b/amm/compiler/src/main/scala-2/ammonite/compiler/Pressy.scala
@@ -335,7 +335,13 @@ object Pressy {
 
       val signatures = all.collect { case (name, Some(defn)) => defn }.sorted.distinct
 
-      (i - prefix.length, allNames, signatures)
+      val isPartialIvyImport = allNames.isEmpty &&
+        snippet.split("\\s+|`").startsWith(Seq("import", "$ivy.")) &&
+        snippet.count(_ == '`') == 1
+
+      if (isPartialIvyImport) {
+        complete(snippetIndex, previousImports, snippet + "`")
+      } else (i - prefix.length, allNames, signatures)
     }
 
     def shutdownPressy() = {

--- a/amm/repl/src/test/scala/ammonite/interp/AutocompleteTests.scala
+++ b/amm/repl/src/test/scala/ammonite/interp/AutocompleteTests.scala
@@ -279,6 +279,15 @@ object AutocompleteTests extends TestSuite{
           """import $ivy.{<from>`io.get-coursier::coursier-co<caret>`}""",
           Set("`io.get-coursier::coursier-core") ^ _.filterNot(_.contains("_sjs"))
         )
+        // Completions when the ivy import has no closing backtick
+        complete(
+          """import $ivy.<from>`io.get-c<caret>""",
+          Set("`io.get-coursier") ^ _
+        )
+        complete(
+          """import $ivy.<from>`io.get-coursier::coursier-co<caret>""",
+          Set("`io.get-coursier::coursier-core") ^ _.filterNot(_.contains("_sjs"))
+        )
         // these rely on versions not around in 2.13
         if (scala.util.Properties.versionNumberString.startsWith("2.12.")) {
           complete(


### PR DESCRIPTION
Hi, this PR is a (partial, and Scala 2 only - there appears to be other issues with completions for Scala 3?) fix for https://github.com/com-lihaoyi/Ammonite/issues/965:

https://user-images.githubusercontent.com/17688577/188308492-22450d23-2e45-4c18-9337-dcc2244d5995.mp4

Essentially, if it turns out there are no completion candidates for a snippet, and the the snippet starts with 
```
$ivy.`
```
We just retry by appending a backtick if the string only contains only one backtick... more of a workaround than an in depth fix  described in https://github.com/com-lihaoyi/Ammonite/issues/965#issuecomment-495857542 (there are many valid cases this wouldn't touch), but I hope it would cover the most common ways people would use `import $ivy`, the case described in the issue for example.

Let me know what you think anyway, thanks :slightly_smiling_face: 