### PR TITLE
add @main entrypoint support for Scala 3

### DIFF
--- a/amm/src/main/scala/ammonite/main/Scripts.scala
+++ b/amm/src/main/scala/ammonite/main/Scripts.scala
@@ -17,12 +17,7 @@ object Scripts {
                 scriptArgs: Seq[String] = Nil) = {
     interp.watch(path)
     val (pkg, wrapper) = Util.pathToPackageWrapper(Seq(), path relativeTo wd)
-
-
-    val genRoutesCode =
-      // Entrypoints are not supported in Scala 3 for now (its macros are Scala 2-only)
-      if (interp.compilerBuilder.scalaVersion.startsWith("3.")) "null"
-      else "mainargs.ParserForMethods[$routesOuter.type]($routesOuter)"
+    val genRoutesCode = "mainargs.ParserForMethods[$routesOuter.type]($routesOuter)"
 
     for{
       scriptTxt <- try Res.Success(Util.normalizeNewlines(os.read(path))) catch{

--- a/amm/src/test/scala/ammonite/main/MainTests.scala
+++ b/amm/src/test/scala/ammonite/main/MainTests.scala
@@ -292,11 +292,5 @@ class MainTests extends TestSuite{
 }
 
 object MainTests extends MainTests {
-  val isScala2 = ammonite.compiler.CompilerBuilder.scalaVersion.startsWith("2.")
-  override def tests =
-    if (isScala2) super.tests
-    else
-      Tests {
-        test("Disabled in Scala 3") - "Disabled in Scala 3"
-      }
+  super.tests
 }

--- a/amm/src/test/scala/ammonite/main/MainTests.scala
+++ b/amm/src/test/scala/ammonite/main/MainTests.scala
@@ -9,7 +9,7 @@ import utest._
   * Tests around Ammonite's CLI handling of main methods, argument parsing,
   * and the associated error behavior if the caller messes up.
  */
-class MainTests extends TestSuite{
+object MainTests extends TestSuite{
   def exec(p: String, args: String*) =
     new InProcessMainMethodRunner(InProcessMainMethodRunner.base / 'mains / p, Nil, args)
 
@@ -289,8 +289,4 @@ class MainTests extends TestSuite{
       }
     }
   }
-}
-
-object MainTests extends MainTests {
-  super.tests
 }

--- a/amm/src/test/scala/ammonite/main/MainTests.scala
+++ b/amm/src/test/scala/ammonite/main/MainTests.scala
@@ -97,9 +97,15 @@ object MainTests extends TestSuite{
           )
           assert(out.contains(expected.trim))
         }
+
         test("emptyArg"){
-          val evaled = exec("ArgList.sc", "")
-          assert(evaled.success)
+          val isScala2 = ammonite.compiler.CompilerBuilder.scalaVersion.startsWith("2.")
+          if (isScala2) {
+            val evaled = exec("ArgList.sc", "")
+            assert(evaled.success)
+          } else {
+            "Disabled in Scala 3"
+          }
         }
       }
     }

--- a/build.sc
+++ b/build.sc
@@ -185,6 +185,9 @@ trait AmmInternalModule extends CrossSbtModule with Bloop.Module{
       else Agg[Dep]()
     )
   }
+
+  // We compile with mainargs_2.13, but for the Scala 3 target we actually ship mainargs_3,
+  // because it contains Scala 3 macros which are required at runtime to find the main class entrypoint. 
   def runIvyDeps =
     if (scala3Versions.contains(crossScalaVersion))
       Agg(ivy"com.lihaoyi:mainargs_3:${Deps.mainargs.dep.version}")

--- a/build.sc
+++ b/build.sc
@@ -689,6 +689,12 @@ class MainModule(val crossScalaVersion: String)
       Deps.scalaJava8Compat
     )
 
+    def runIvyDeps =
+      if (scala3Versions.contains(crossScalaVersion))
+        Agg(ivy"com.lihaoyi:mainargs_3:${Deps.mainargs.dep.version}")
+      else
+        Agg(Deps.mainargs)
+
 
     def thinWhitelist = T{
       generateApiWhitelist(
@@ -715,7 +721,6 @@ class MainModule(val crossScalaVersion: String)
       amm.repl().sources() ++
       sources() ++
       externalSources()
-
   }
 }
 

--- a/build.sc
+++ b/build.sc
@@ -553,7 +553,15 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
       def ivyDeps = super.ivyDeps() ++ amm.compiler().ivyDeps() ++ Agg(
         withDottyCompat(Deps.scalazCore, scalaVersion())
       )
-    }
+
+      // We compile with mainargs_2.13, but for the Scala 3 target we actually ship mainargs_3,
+      // because it contains Scala 3 macros which are required at runtime to find the main class entrypoint. 
+      def runIvyDeps =
+        if (scala3Versions.contains(crossScalaVersion))
+          Agg(ivy"com.lihaoyi:mainargs_3:${Deps.mainargs.dep.version}")
+        else
+          Agg(Deps.mainargs)
+        }
   }
 
   // When built with crossScalaVersion == 3.x, amm itself is still compiled with


### PR DESCRIPTION
mainargs 0.2.3 [added support for scala3](https://github.com/com-lihaoyi/mainargs/pull/18)

To test (manually):

test.sc:
```scala
@main def main(name: String) = {
  println(s"Hello, $name!")
}
```

```bash
mill -i "amm[3.2.0].assembly" && out/amm/3.2.0/assembly.dest/out.jar test.sc --name Michael
mill -i "amm[2.13.9].assembly" && out/amm/2.13.9/assembly.dest/out.jar test.sc --name Michael
```