### PR TITLE
Fix issues with `_3` and `_2.13` dependencies

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -186,12 +186,13 @@ trait AmmInternalModule extends CrossSbtModule with Bloop.Module{
     acyclicOptions ++ tastyReaderOptions
   }
   // In Scala 3 we want to use the Scala 2.13 deps at compile time
+  // (only in modules where supports3 == false, which are compiled using Scala 2.13)
   // but the Scala 3 libs at runtime. So we override the tasks used
-  // to fetch the dependencies used to compile to force the 2.13 libs
+  // to fetch the dependencies used during compilation to force the 2.13 libs
   def myResolvedIvyDeps: T[Agg[PathRef]] = T {
     resolveDeps(T.task {
       (transitiveCompileIvyDeps() ++ transitiveIvyDeps()).map { dep =>
-        if (isScala3(crossScalaVersion) && use_3Libs.contains(dep.dep.module.name.value)) {
+        if (isScala3(crossScalaVersion) && !supports3 && use_3Libs.contains(dep.dep.module.name.value)) {
           dep.copy(
           dep = dep.dep.withModule(
             dep.dep.module

--- a/build.sc
+++ b/build.sc
@@ -115,19 +115,22 @@ object Deps {
     // with the Scala 2.13 artifact, while using the Scala 3 artifact in
     // the pom and at runtime. Please add here any Scala library using macros
     // and add it to `ivyDeps` wrapping it with `Deps.use_3`
-    private val deps = Seq(
-      ivy"com.lihaoyi::mainargs:0.3.0",
-      ivy"com.lihaoyi::fansi:0.4.0",
-      ivy"com.lihaoyi::pprint:0.7.3",
-      ivy"com.lihaoyi::sourcecode:0.2.7"
-    )
+    private def deps(crossScalaVersion: String) = {
+      val fansiVersion = if (crossScalaVersion.startsWith("3.0.")) "0.3.1" else "0.4.0"
+      Seq(
+        ivy"com.lihaoyi::mainargs:0.3.0",
+        ivy"com.lihaoyi::fansi:$fansiVersion",
+        ivy"com.lihaoyi::pprint:0.7.3",
+        ivy"com.lihaoyi::sourcecode:0.2.7"
+      )
+    }
 
-    val depsNames = deps.map(_.dep.module.name.value)
+    val depsNames = deps(scala2_13Versions.last).map(_.dep.module.name.value)
 
     // Since we compile using Scala 2.13, Scala 2.13 libraries are used
     // by default. This forces Scala 3 libraries to use the `_3` suffix
     def apply(name: String, crossScalaVersion: String): Dep = {
-      val dep = deps.find(_.dep.module.name.value == name).get
+      val dep = deps(crossScalaVersion).find(_.dep.module.name.value == name).get
       dep.cross match {
         case cross: CrossVersion.Binary if isScala3(crossScalaVersion) =>
           dep.copy(cross = CrossVersion.Constant(value = "_3", platformed = dep.cross.platformed))

--- a/build.sc
+++ b/build.sc
@@ -94,7 +94,7 @@ object Deps {
   val bcprovJdk15on = ivy"org.bouncycastle:bcprov-jdk15on:1.56"
   val cask = ivy"com.lihaoyi::cask:0.6.0"
   val coursierInterface = ivy"io.get-coursier:interface:0.0.21"
-  val fansi = ivy"com.lihaoyi::fansi:0.3.0"
+  val fansi = ivy"com.lihaoyi::fansi:0.4.0"
   val fastparse = ivy"com.lihaoyi::fastparse:$fastparseVersion"
   val javaparserCore = ivy"com.github.javaparser:javaparser-core:3.2.5"
   val javassist = ivy"org.javassist:javassist:3.21.0-GA"


### PR DESCRIPTION
Fixes #1241
Having a sane classpath using the Scala 2.13 compiler to compile a Scala 3 project is _hard_.
This uses some tricks to compile using Scala 2.13 dependencies (since we need the Scala 2.13 macros) and then change the artifacts with Scala 3 artifacts so the Ammonite runtime can compile the macros using the Scala 3 compiler.