### PR TITLE
add @main entrypoint support for Scala 3

### DIFF
--- a/amm/src/main/scala/ammonite/main/Scripts.scala
+++ b/amm/src/main/scala/ammonite/main/Scripts.scala
@@ -17,12 +17,7 @@ object Scripts {
                 scriptArgs: Seq[String] = Nil) = {
     interp.watch(path)
     val (pkg, wrapper) = Util.pathToPackageWrapper(Seq(), path relativeTo wd)
-
-
-    val genRoutesCode =
-      // Entrypoints are not supported in Scala 3 for now (its macros are Scala 2-only)
-      if (interp.compilerBuilder.scalaVersion.startsWith("3.")) "null"
-      else "mainargs.ParserForMethods[$routesOuter.type]($routesOuter)"
+    val genRoutesCode = "mainargs.ParserForMethods[$routesOuter.type]($routesOuter)"
 
     for{
       scriptTxt <- try Res.Success(Util.normalizeNewlines(os.read(path))) catch{

--- a/amm/src/test/scala/ammonite/main/MainTests.scala
+++ b/amm/src/test/scala/ammonite/main/MainTests.scala
@@ -9,7 +9,7 @@ import utest._
   * Tests around Ammonite's CLI handling of main methods, argument parsing,
   * and the associated error behavior if the caller messes up.
  */
-class MainTests extends TestSuite{
+object MainTests extends TestSuite{
   def exec(p: String, args: String*) =
     new InProcessMainMethodRunner(InProcessMainMethodRunner.base / 'mains / p, Nil, args)
 
@@ -98,8 +98,13 @@ class MainTests extends TestSuite{
           assert(out.contains(expected.trim))
         }
         test("emptyArg"){
-          val evaled = exec("ArgList.sc", "")
-          assert(evaled.success)
+          val isScala2 = ammonite.compiler.CompilerBuilder.scalaVersion.startsWith("2.")
+          if (isScala2) {
+            val evaled = exec("ArgList.sc", "")
+            assert(evaled.success)
+          } else {
+            "Disabled in Scala 3"
+          }
         }
       }
     }
@@ -289,14 +294,4 @@ class MainTests extends TestSuite{
       }
     }
   }
-}
-
-object MainTests extends MainTests {
-  val isScala2 = ammonite.compiler.CompilerBuilder.scalaVersion.startsWith("2.")
-  override def tests =
-    if (isScala2) super.tests
-    else
-      Tests {
-        test("Disabled in Scala 3") - "Disabled in Scala 3"
-      }
 }


### PR DESCRIPTION
mainargs 0.2.3 added support for scala3 :tada:
https://github.com/com-lihaoyi/mainargs/pull/18

The first attempt to upgrade and enable mainargs was https://github.com/com-lihaoyi/Ammonite/pull/1298, but the build changes were better handled by https://github.com/com-lihaoyi/Ammonite/pull/1301

So the only thing left is reenabling mainargs for Scala 3.