### PR TITLE
fix amm-util java.rt.export race condition: synchronize

### DIFF
--- a/amm/util/src/main/java/io/github/retronym/java9rtexport/Export.java
+++ b/amm/util/src/main/java/io/github/retronym/java9rtexport/Export.java
@@ -73,7 +73,12 @@ public class Export {
         return tempFile;
     }
 
-    public static boolean rtTo(File dest, boolean verbose) {
+    /**
+     * Needs to be `synchronized` because java.nio.file.Files.copy isn't thread safe:
+     * https://stackoverflow.com/questions/69796396/is-files-copy-a-thread-safe-function-in-java
+     * and our own handling of "if !exists, then copy" isn't either...
+     */
+    public static synchronized boolean rtTo(File dest, boolean verbose) {
         try {
             if (!dest.exists()) {
                 if (verbose) {


### PR DESCRIPTION
`Export.rtTo` needs to be `synchronized` because java.nio.file.Files.copy isn't thread safe: 
https://stackoverflow.com/questions/69796396/is-files-copy-a-thread-safe-function-in-java
and our own handling of `if !exists, then copy` isn't either...

This is very much a concurrency edge case, albeit one that we regularly run into. Without this change, we regularly run into the below when running tests in parallel.

```
java.nio.file.FileAlreadyExistsException: /home/runner/.ammonite/rt-17.0.5.jar
	at java.base/sun.nio.fs.UnixCopyFile.copy(UnixCopyFile.java:573)
	at java.base/sun.nio.fs.UnixFileSystemProvider.copy(UnixFileSystemProvider.java:257)
	at java.base/java.nio.file.Files.copy(Files.java:1305)
	at io.github.retronym.java9rtexport.Export.rtTo(Export.java:88)
	at io.github.retronym.java9rtexport.Export.rtAt(Export.java:100)
	at io.github.retronym.java9rtexport.Export.rtAt(Export.java:105)
	at ammonite.util.Classpath$.classpath(Classpath.scala:76)
```