### PR TITLE
Update upickle to 3.0.0-M2

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -79,6 +79,7 @@ object Deps {
   val cask = ivy"com.lihaoyi::cask:0.6.0"
   val coursierInterface = ivy"io.get-coursier:interface:1.0.11"
   val fastparse = ivy"com.lihaoyi::fastparse:$fastparseVersion"
+  val geny = ivy"com.lihaoyi::geny:1.0.0"
   val javaparserCore = ivy"com.github.javaparser:javaparser-core:3.2.5"
   val javassist = ivy"org.javassist:javassist:3.21.0-GA"
   val jlineJna = ivy"org.jline:jline-terminal-jna:3.14.1"
@@ -123,9 +124,6 @@ object Deps {
       }
     }
   }
-  object geny extends Use3Dep {
-    override def dep(scalaVersion: String) = ivy"com.lihaoyi::geny:1.0.0"
-  }
   object mainargs extends Use3Dep {
     override def dep(scalaVersion: String) = ivy"com.lihaoyi::mainargs:0.3.0"
   }
@@ -145,7 +143,7 @@ object Deps {
     override def dep(scalaVersion: String) = ivy"com.lihaoyi::sourcecode:0.2.7"
   }
 
-  val use_3_deps = Seq(geny, mainargs, fansi, pprint, scalaCollectionCompat, sourcecode)
+  val use_3_deps = Seq(mainargs, fansi, pprint, scalaCollectionCompat, sourcecode)
 }
 
 // Adapted from https://github.com/lihaoyi/mill/blob/0.9.3/scalalib/src/MiscModule.scala/#L80-L100
@@ -534,7 +532,7 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
       def moduleDeps = Seq(amm.util(), interp.api())
       def ivyDeps = Agg(
         Deps.mainargs.use_3(crossScalaVersion),
-        Deps.geny.use_3(crossScalaVersion)
+        Deps.geny
       )
 
       def generatedSources = T{

--- a/build.sc
+++ b/build.sc
@@ -140,7 +140,7 @@ object Deps {
     override def dep(scalaVersion: String) = ivy"org.scala-lang.modules::scala-collection-compat:2.8.1"
   }
   object sourcecode extends Use3Dep {
-    override def dep(scalaVersion: String) = ivy"com.lihaoyi::sourcecode:0.2.7"
+    override def dep(scalaVersion: String) = ivy"com.lihaoyi::sourcecode:0.3.0"
   }
 
   val use_3_deps = Seq(mainargs, fansi, pprint, scalaCollectionCompat, sourcecode)

--- a/build.sc
+++ b/build.sc
@@ -105,7 +105,7 @@ object Deps {
   val slf4jNop = ivy"org.slf4j:slf4j-nop:1.7.12"
   val sshdCore = ivy"org.apache.sshd:sshd-core:1.2.0"
   val trees = ivy"org.scalameta::trees:$scalametaVersion"
-  val upickle = ivy"com.lihaoyi::upickle:2.0.0"
+  val upickle = ivy"com.lihaoyi::upickle:3.0.0-M2"
   val utest = ivy"com.lihaoyi::utest:0.8.1"
 
   /** A dependency containing Scala 2 macros which we apply at compile-time, even when targetting Scala 3. */

--- a/build.sc
+++ b/build.sc
@@ -42,12 +42,11 @@ val cross2_3Version = (scala3Ver: String) =>
 
 val scala2_12Versions = Seq("2.12.8", "2.12.9", "2.12.10", "2.12.11", "2.12.12", "2.12.13", "2.12.14", "2.12.15", "2.12.16", "2.12.17")
 val scala2_13Versions = Seq("2.13.0", "2.13.1", "2.13.2", "2.13.3", "2.13.4", "2.13.5", "2.13.6", "2.13.7", "2.13.8", "2.13.9", "2.13.10")
-val scala30Versions = Seq("3.0.0", "3.0.1", "3.0.2")
 val scala31Versions = Seq("3.1.0", "3.1.1", "3.1.2", "3.1.3")
 val scala32Versions = Seq("3.2.0", "3.2.1", "3.2.2")
-val scala3Versions = scala30Versions ++ scala31Versions ++ scala32Versions
+val scala3Versions = scala31Versions ++ scala32Versions
 
-val binCrossScalaVersions = Seq(scala2_12Versions.last, scala2_13Versions.last, scala30Versions.last, scala31Versions.last, scala32Versions.last)
+val binCrossScalaVersions = Seq(scala2_12Versions.last, scala2_13Versions.last, scala31Versions.last, scala32Versions.last)
 def isScala2_12_10OrLater(sv: String): Boolean = {
   (sv.startsWith("2.12.") && sv.stripPrefix("2.12.").length > 1) || (sv.startsWith("2.13.") && sv != "2.13.0")
 }
@@ -58,7 +57,7 @@ val latestAssemblies = binCrossScalaVersions.map(amm(_).assembly)
 println("GITHUB REF " + sys.env.get("GITHUB_REF"))
 
 val (buildVersion, unstable) = scala.util.Try(
-  os.proc('git, 'describe, "--exact-match", "--tags", "--always", gitHead)
+  os.proc("git", "describe", "--exact-match", "--tags", "--always", gitHead)
     .call()
     .out
     .trim

--- a/build.sc
+++ b/build.sc
@@ -123,6 +123,9 @@ object Deps {
       }
     }
   }
+  object geny extends Use3Dep {
+    override def dep(scalaVersion: String) = ivy"com.lihaoyi::geny:1.0.0"
+  }
   object mainargs extends Use3Dep {
     override def dep(scalaVersion: String) = ivy"com.lihaoyi::mainargs:0.3.0"
   }
@@ -142,7 +145,7 @@ object Deps {
     override def dep(scalaVersion: String) = ivy"com.lihaoyi::sourcecode:0.2.7"
   }
 
-  val use_3_deps = Seq(mainargs, fansi, pprint, scalaCollectionCompat, sourcecode)
+  val use_3_deps = Seq(geny, mainargs, fansi, pprint, scalaCollectionCompat, sourcecode)
 }
 
 // Adapted from https://github.com/lihaoyi/mill/blob/0.9.3/scalalib/src/MiscModule.scala/#L80-L100
@@ -530,7 +533,8 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
       def dependencyResourceFileName = "amm-dependencies.txt"
       def moduleDeps = Seq(amm.util(), interp.api())
       def ivyDeps = Agg(
-        Deps.mainargs.use_3(crossScalaVersion)
+        Deps.mainargs.use_3(crossScalaVersion),
+        Deps.geny.use_3(crossScalaVersion)
       )
 
       def generatedSources = T{

--- a/build.sc
+++ b/build.sc
@@ -85,7 +85,7 @@ object Deps {
   val jlineReader = ivy"org.jline:jline-reader:3.14.1"
   val jlineTerminal = ivy"org.jline:jline-terminal:3.14.1"
   val jsch = ivy"com.jcraft:jsch:0.1.54"
-  val osLib = ivy"com.lihaoyi::os-lib:0.8.0"
+  val osLib = ivy"com.lihaoyi::os-lib:0.9.0"
   val requests = ivy"com.lihaoyi::requests:0.7.0"
   val scalacheck = ivy"org.scalacheck::scalacheck:1.15.4"
   def scalaCompiler(scalaVersion: String) = ivy"org.scala-lang:scala-compiler:${scalaVersion}"

--- a/integration/src/test/scala/ammonite/integration/BasicTests.scala
+++ b/integration/src/test/scala/ammonite/integration/BasicTests.scala
@@ -51,7 +51,7 @@ object BasicTests extends TestSuite{
           scriptAddr
           // Somehow this is being set of travis and causing weird errors/warnings
         ).call(env = Map("_JAVA_OPTIONS" -> null))
-        assert(evaled.out.trim == "Script Worked!!" && evaled.err.string.isEmpty)
+        assert(evaled.out.trim == "Script Worked!!" && evaled.err.text().isEmpty)
       }
     }
     test("scalacNotLoadedByCachedScripts"){
@@ -158,21 +158,21 @@ object BasicTests extends TestSuite{
 
     test("classloaders"){
       val evaled = exec(os.rel / 'basic / "Resources.sc")
-      assert(evaled.out.string.contains("1745"))
+      assert(evaled.out.text().contains("1745"))
     }
     test("testSilentScriptRunning"){
       val evaled1 = exec(os.rel / 'basic/"Hello.sc")
       // check Compiling Script is being printed
 
-      assert(evaled1.err.string.contains("Compiling"))
+      assert(evaled1.err.text().contains("Compiling"))
       val evaled2 = execSilent(os.rel / 'basic/"Hello.sc")
       // make sure with `-s` flag script running is silent
-      assert(!evaled2.err.string.contains("Compiling"))
+      assert(!evaled2.err.text().contains("Compiling"))
     }
     test("testSilentRunningWithExceptions"){
       val errorMsg = intercept[os.SubprocessException]{
         exec(os.rel / 'basic/"Failure.sc")
-      }.result.err.string
+      }.result.err.text()
 
       val expected =
         if (isScala2) "not found: value x"
@@ -182,7 +182,7 @@ object BasicTests extends TestSuite{
     test("testSilentIvyExceptions"){
       val errorMsg = intercept[os.SubprocessException]{
         exec(os.rel / 'basic/"wrongIvyCordinates.sc")
-      }.result.err.string
+      }.result.err.text()
 
 
       assert(errorMsg.contains("Failed to resolve ivy dependencies"))
@@ -236,7 +236,7 @@ object BasicTests extends TestSuite{
 
           // 3. use published artifact in a script
           val evaled = execWithHome(home, os.rel / 'basic / script)
-          assert(evaled.out.string.contains(theThing))
+          assert(evaled.out.text().contains(theThing))
         }
 
         publishJarAndRunScript("thing1", "ivyResolveSnapshot1.sc", "0.1-SNAPSHOT", firstRun = true)
@@ -257,13 +257,13 @@ object BasicTests extends TestSuite{
       def positiveArgsTest() = {
         val evaled = exec(os.rel / 'basic/"MultiMain.sc", "functionB", "2", "foo")
 
-        val out = evaled.out.string
+        val out = evaled.out.text()
         assert(out == ("Hello! foofoo ." + Util.newLine))
       }
       def specifyMainTest() = {
         val evaled = intercept[os.SubprocessException](exec(os.rel / 'basic/"MultiMain.sc"))
 
-        val out = evaled.result.err.string
+        val out = evaled.result.err.text()
         val expected = Util.normalizeNewlines(
           s"""Need to specify a sub command: mainA, functionB""".stripMargin
         )

--- a/integration/src/test/scala/ammonite/integration/ErrorTruncationTests.scala
+++ b/integration/src/test/scala/ammonite/integration/ErrorTruncationTests.scala
@@ -17,7 +17,7 @@ object ErrorTruncationTests extends TestSuite{
         intercept[os.SubprocessException]{ exec(file) }
           .result
           .err
-          .string
+          .text()
       )
     ).plainText
     //This string gets included on windows due to environment variable set additionally

--- a/integration/src/test/scala/ammonite/integration/LineNumberTests.scala
+++ b/integration/src/test/scala/ammonite/integration/LineNumberTests.scala
@@ -13,7 +13,7 @@ object LineNumberTests extends TestSuite{
     def checkErrorMessage(file: os.RelPath, expected: String): Unit = {
       val e = intercept[os.SubprocessException]{
         exec(file)
-      }.result.err.string
+      }.result.err.text()
       assert(TestUtils.containsLines(e, expected))
     }
 

--- a/integration/src/test/scala/ammonite/integration/ProjectTests.scala
+++ b/integration/src/test/scala/ammonite/integration/ProjectTests.scala
@@ -23,7 +23,7 @@ object ProjectTests extends TestSuite{
       if (!Util.windowsPlatform) {
         if (scalaVersion.startsWith("2.11.") && javaVersion.startsWith("1.8.")){
           val evaled = exec(os.rel/'basic/"PlayFramework.sc")
-          assert(evaled.out.string.contains("Hello bar"))
+          assert(evaled.out.text().contains("Hello bar"))
         }
       }
     }
@@ -45,7 +45,7 @@ object ProjectTests extends TestSuite{
       if (!Util.windowsPlatform) {
         if (scalaVersion.startsWith("2.11.") && javaVersion.startsWith("1.8.")){
           val evaled = exec(os.rel / 'basic/"Spark2.sc")
-          assert(evaled.out.string.contains("fake db write"))
+          assert(evaled.out.text().contains("fake db write"))
         }
       }
     }


### PR DESCRIPTION
This is a binary incompatible change! The next release version after merge is probably `3.0.0`.

I dropped support for Scala 3.0.x due to the fact, that upickle_3 3.0.0-M2 is build against Scala 3.1.

Ammonite depends also on geny but never made that dependency explicit. I changed that and added a direct dependency where appropriate. With the bump of upickle, we implicitly also bump geny from 0.7.0 to 1.0.0. As a consequence, I also had to update os-lib from 0.8.0 to 0.9.0 as it is also depending on geny, and only version 0.9.0 is compatible to geny 1.0.0.