### PR TITLE
Tweak Interpreter constructor

### DIFF
--- a/amm/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -86,7 +86,7 @@ class Repl(input: InputStream,
   )
   val interp = new Interpreter(
     compilerBuilder,
-    parser,
+    () => parser,
     getFrame = () => frames().head,
     createFrame = () => { val f = sess0.childFrame(frames().head); frames() = f :: frames(); f },
     replCodeWrapper = replCodeWrapper,

--- a/amm/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -73,22 +73,25 @@ class Repl(input: InputStream,
 
   def usedEarlierDefinitions = frames().head.usedEarlierDefinitions
 
+  val interpParams = Interpreter.Parameters(
+    printer = printer,
+    storage = storage,
+    wd = wd,
+    colors = colors,
+    verboseOutput = true,
+    initialClassLoader = initialClassLoader,
+    importHooks = importHooks,
+    classPathWhitelist = classPathWhitelist,
+    alreadyLoadedDependencies = alreadyLoadedDependencies
+  )
   val interp = new Interpreter(
     compilerBuilder,
     parser,
-    printer,
-    storage,
-    wd,
-    colors,
-    verboseOutput = true,
     getFrame = () => frames().head,
     createFrame = () => { val f = sess0.childFrame(frames().head); frames() = f :: frames(); f },
-    initialClassLoader = initialClassLoader,
     replCodeWrapper = replCodeWrapper,
     scriptCodeWrapper = scriptCodeWrapper,
-    alreadyLoadedDependencies = alreadyLoadedDependencies,
-    importHooks,
-    classPathWhitelist = classPathWhitelist
+    parameters = interpParams
   )
 
   val bridges = Seq(

--- a/amm/repl/src/test/scala/ammonite/TestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/TestRepl.scala
@@ -82,7 +82,7 @@ class TestRepl(compilerBuilder: ICompilerBuilder = CompilerBuilder) { self =>
   val interp = try {
     new Interpreter(
       compilerBuilder,
-      parser,
+      () => parser,
       getFrame = () => frames().head,
       createFrame = () => { val f = sess0.childFrame(frames().head); frames() = f :: frames(); f },
       replCodeWrapper = codeWrapper,

--- a/amm/repl/src/test/scala/ammonite/TestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/TestRepl.scala
@@ -69,22 +69,25 @@ class TestRepl(compilerBuilder: ICompilerBuilder = CompilerBuilder) { self =>
   val parser = ammonite.compiler.Parsers
 
   var currentLine = 0
+  val interpParams = Interpreter.Parameters(
+    printer = printer0,
+    storage = storage,
+    wd = os.pwd,
+    colors = Ref(Colors.BlackWhite),
+    initialClassLoader = initialClassLoader,
+    alreadyLoadedDependencies = Defaults.alreadyLoadedDependencies("amm-test-dependencies.txt"),
+    importHooks = ImportHook.defaults,
+    classPathWhitelist = ammonite.repl.Repl.getClassPathWhitelist(thin = true)
+  )
   val interp = try {
     new Interpreter(
       compilerBuilder,
       parser,
-      printer0,
-      storage = storage,
-      wd = os.pwd,
-      colors = Ref(Colors.BlackWhite),
       getFrame = () => frames().head,
       createFrame = () => { val f = sess0.childFrame(frames().head); frames() = f :: frames(); f },
-      initialClassLoader = initialClassLoader,
       replCodeWrapper = codeWrapper,
       scriptCodeWrapper = codeWrapper,
-      alreadyLoadedDependencies = Defaults.alreadyLoadedDependencies("amm-test-dependencies.txt"),
-      importHooks = ImportHook.defaults,
-      classPathWhitelist = ammonite.repl.Repl.getClassPathWhitelist(thin = true)
+      parameters = interpParams
     )
 
   }catch{ case e: Throwable =>

--- a/amm/repl/src/test/scala/ammonite/TestUtils.scala
+++ b/amm/repl/src/test/scala/ammonite/TestUtils.scala
@@ -39,7 +39,7 @@ object TestUtils {
     )
     val interp = new Interpreter(
       ammonite.compiler.CompilerBuilder,
-      ammonite.compiler.Parsers,
+      () => ammonite.compiler.Parsers,
 
       getFrame = () => startFrame,
       createFrame = () => throw new Exception("unsupported"),

--- a/amm/repl/src/test/scala/ammonite/TestUtils.scala
+++ b/amm/repl/src/test/scala/ammonite/TestUtils.scala
@@ -24,10 +24,7 @@ object TestUtils {
     val initialClassLoader = Thread.currentThread().getContextClassLoader
     val startFrame = Frame.createInitial(initialClassLoader)
     val printStream = new PrintStream(System.out)
-    val interp = new Interpreter(
-      ammonite.compiler.CompilerBuilder,
-      ammonite.compiler.Parsers,
-
+    val interpParams = Interpreter.Parameters(
       printer = Printer(
         printStream, new PrintStream(System.err), printStream,
         println, println, println
@@ -35,14 +32,20 @@ object TestUtils {
       storage = storage,
       wd = os.pwd,
       colors = Ref(Colors.BlackWhite),
-      getFrame = () => startFrame,
-      createFrame = () => throw new Exception("unsupported"),
       initialClassLoader = initialClassLoader,
-      replCodeWrapper = DefaultCodeWrapper,
-      scriptCodeWrapper = DefaultCodeWrapper,
       alreadyLoadedDependencies = Defaults.alreadyLoadedDependencies("amm-test-dependencies.txt"),
       importHooks = ImportHook.defaults,
       classPathWhitelist = ammonite.repl.Repl.getClassPathWhitelist(thin = true)
+    )
+    val interp = new Interpreter(
+      ammonite.compiler.CompilerBuilder,
+      ammonite.compiler.Parsers,
+
+      getFrame = () => startFrame,
+      createFrame = () => throw new Exception("unsupported"),
+      replCodeWrapper = DefaultCodeWrapper,
+      scriptCodeWrapper = DefaultCodeWrapper,
+      parameters = interpParams
     )
     // Provide a custom predef so we can verify in tests that the predef gets cached
     for {

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -173,22 +173,25 @@ case class Main(predefCode: String = "",
         PredefInfo(Name("CodePredef"), predefCode, false, None)
       )
       lazy val parser0 = parser()
+      val interpParams = Interpreter.Parameters(
+        printer = printer,
+        storage = storageBackend,
+        wd = wd,
+        colors = colorsRef,
+        verboseOutput = verboseOutput,
+        initialClassLoader = initialClassLoader,
+        importHooks = importHooks,
+        classPathWhitelist = classPathWhitelist,
+        alreadyLoadedDependencies = alreadyLoadedDependencies
+      )
       val interp = new Interpreter(
         ammonite.compiler.CompilerBuilder,
         parser0,
-        printer,
-        storageBackend,
-        wd,
-        colorsRef,
-        verboseOutput,
         () => frame,
         () => throw new Exception("session loading / saving not possible here"),
-        initialClassLoader = initialClassLoader,
         replCodeWrapper,
         scriptCodeWrapper,
-        alreadyLoadedDependencies = alreadyLoadedDependencies,
-        importHooks = importHooks,
-        classPathWhitelist = classPathWhitelist
+        parameters = interpParams
       )
       val bridges = Seq(
         (

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -186,7 +186,7 @@ case class Main(predefCode: String = "",
       )
       val interp = new Interpreter(
         ammonite.compiler.CompilerBuilder,
-        parser0,
+        () => parser0,
         () => frame,
         () => throw new Exception("session loading / saving not possible here"),
         replCodeWrapper,


### PR DESCRIPTION
A simple clean-up of the constructor of `ammonite.interp.Interpreter`. This moves all parameters that have or can have sensible defaults to a separate `Interpreter.Parameters` case class, and uses the same way of passing by-name values for the other parameters.