### PR TITLE
Allow to write REPL byte code to a directory

### DIFF
--- a/amm/compiler/interface/src/main/scala/ammonite/compiler/iface/CompilerLifecycleManager.scala
+++ b/amm/compiler/interface/src/main/scala/ammonite/compiler/iface/CompilerLifecycleManager.scala
@@ -13,6 +13,8 @@ abstract class CompilerLifecycleManager {
 
   def scalaVersion: String
 
+  def outputDir: Option[Path]
+
   def init(force: Boolean = false): Unit
 
   def complete(

--- a/amm/compiler/src/main/scala-2/ammonite/compiler/CompilerBuilder.scala
+++ b/amm/compiler/src/main/scala-2/ammonite/compiler/CompilerBuilder.scala
@@ -15,7 +15,7 @@ import scala.reflect.io.VirtualDirectory
 import scala.tools.nsc.Settings
 
 
-object CompilerBuilder extends ICompilerBuilder {
+case class CompilerBuilder() extends ICompilerBuilder {
   def create(
     initialClassPath: Seq[URL],
     classPath: Seq[URL],
@@ -87,5 +87,9 @@ object CompilerBuilder extends ICompilerBuilder {
       initialClassLoader
     )
 
+  def scalaVersion = CompilerBuilder.scalaVersion
+}
+
+object CompilerBuilder {
   def scalaVersion = scala.util.Properties.versionNumberString
 }

--- a/amm/compiler/src/main/scala-2/ammonite/compiler/CompilerBuilder.scala
+++ b/amm/compiler/src/main/scala-2/ammonite/compiler/CompilerBuilder.scala
@@ -15,7 +15,9 @@ import scala.reflect.io.VirtualDirectory
 import scala.tools.nsc.Settings
 
 
-case class CompilerBuilder() extends ICompilerBuilder {
+case class CompilerBuilder(
+  outputDir: Option[Path] = None
+) extends ICompilerBuilder {
   def create(
     initialClassPath: Seq[URL],
     classPath: Seq[URL],
@@ -29,7 +31,7 @@ case class CompilerBuilder() extends ICompilerBuilder {
   ): ICompiler = {
 
     val vd = new VirtualDirectory("(memory)", None)
-    Compiler.addToClasspath(dynamicClassPath, vd)
+    Compiler.addToClasspath(dynamicClassPath, vd, outputDir)
 
     val scalacSettings = {
       // not 100% sure error collection is correct (duplicates?)
@@ -61,6 +63,7 @@ case class CompilerBuilder() extends ICompilerBuilder {
     Compiler(
       classPath,
       vd,
+      outputDir,
       evalClassLoader,
       pluginClassLoader,
       () => (),
@@ -84,7 +87,8 @@ case class CompilerBuilder() extends ICompilerBuilder {
       headFrame,
       dependencyCompleter,
       whiteList,
-      initialClassLoader
+      initialClassLoader,
+      outputDir
     )
 
   def scalaVersion = CompilerBuilder.scalaVersion

--- a/amm/compiler/src/main/scala-2/ammonite/compiler/CompilerExtensions.scala
+++ b/amm/compiler/src/main/scala-2/ammonite/compiler/CompilerExtensions.scala
@@ -3,6 +3,8 @@ package ammonite.compiler
 import ammonite.interp.api.InterpAPI
 import ammonite.repl.api.ReplAPI
 
+import java.nio.file.Path
+
 object CompilerExtensions {
 
   implicit class CompilerInterpAPIExtensions(private val api: InterpAPI) extends AnyVal {
@@ -23,6 +25,14 @@ object CompilerExtensions {
       */
     def preConfigureCompiler(c: scala.tools.nsc.Settings => Unit): Unit =
       compilerManager.preConfigureCompiler(c)
+
+    /**
+      * Directory where the byte code resulting from compiling the user code is written.
+      * This is non-empty only if the `--output-directory` or `--tmp-output-directory` options
+      * are passed to Ammonite upon launch.
+      */
+    def outputDir: Option[Path] =
+      compilerManager.outputDir
   }
 
   implicit class CompilerReplAPIExtensions(private val api: ReplAPI) extends AnyVal {

--- a/amm/compiler/src/main/scala-2/ammonite/compiler/CompilerLifecycleManager.scala
+++ b/amm/compiler/src/main/scala-2/ammonite/compiler/CompilerLifecycleManager.scala
@@ -31,7 +31,8 @@ class CompilerLifecycleManager(
   headFrame: => ammonite.util.Frame,
   dependencyCompleteOpt: => Option[String => (Int, Seq[String])],
   classPathWhitelist: Set[Seq[String]],
-  initialClassLoader: ClassLoader
+  initialClassLoader: ClassLoader,
+  val outputDir: Option[Path]
 ) extends ICompilerLifecycleManager {
 
   def scalaVersion = scala.util.Properties.versionNumberString
@@ -96,6 +97,7 @@ class CompilerLifecycleManager(
       Internal.compiler = Compiler(
         headFrameClassPath,
         dynamicClasspath,
+        outputDir,
         headFrame.classloader,
         headFrame.pluginClassloader,
         () => shutdownPressy(),
@@ -163,7 +165,7 @@ class CompilerLifecycleManager(
     }
 
   def addToClasspath(classFiles: ClassFiles) = synchronized {
-    Compiler.addToClasspath(classFiles, dynamicClasspath)
+    Compiler.addToClasspath(classFiles, dynamicClasspath, outputDir)
   }
   // Not synchronized, since it's part of the exit sequence that needs to run
   // if the repl exits while the warmup code is compiling

--- a/amm/compiler/src/main/scala-3/ammonite/compiler/CompilerBuilder.scala
+++ b/amm/compiler/src/main/scala-3/ammonite/compiler/CompilerBuilder.scala
@@ -12,7 +12,7 @@ import ammonite.compiler.iface.{
 import ammonite.util.Frame
 import dotty.tools.io.AbstractFile
 
-object CompilerBuilder extends ICompilerBuilder:
+case class CompilerBuilder() extends ICompilerBuilder:
 
   def create(
     initialClassPath: Seq[URL],
@@ -38,7 +38,7 @@ object CompilerBuilder extends ICompilerBuilder:
     )
   }
 
-  def scalaVersion = dotty.tools.dotc.config.Properties.versionNumberString
+  def scalaVersion = CompilerBuilder.scalaVersion
 
   def newManager(
     rtCacheDir: Option[Path],
@@ -54,3 +54,6 @@ object CompilerBuilder extends ICompilerBuilder:
       whiteList,
       initialClassLoader
     )
+
+object CompilerBuilder:
+  def scalaVersion = dotty.tools.dotc.config.Properties.versionNumberString

--- a/amm/compiler/src/main/scala-3/ammonite/compiler/CompilerBuilder.scala
+++ b/amm/compiler/src/main/scala-3/ammonite/compiler/CompilerBuilder.scala
@@ -12,7 +12,9 @@ import ammonite.compiler.iface.{
 import ammonite.util.Frame
 import dotty.tools.io.AbstractFile
 
-case class CompilerBuilder() extends ICompilerBuilder:
+case class CompilerBuilder(
+  outputDir: Option[Path] = None
+) extends ICompilerBuilder:
 
   def create(
     initialClassPath: Seq[URL],
@@ -25,8 +27,8 @@ case class CompilerBuilder() extends ICompilerBuilder:
     classPathWhiteList: Set[Seq[String]],
     lineNumberModifier: Boolean
   ): ICompiler = {
-    val tempDir = AbstractFile.getDirectory(os.temp.dir().toNIO)
-    Compiler.addToClasspath(dynamicClassPath, tempDir)
+    val tempDir = AbstractFile.getDirectory(outputDir.getOrElse(os.temp.dir().toNIO))
+    Compiler.addToClasspath(dynamicClassPath, tempDir, outputDir)
     new Compiler(
       tempDir,
       initialClassPath,
@@ -52,7 +54,8 @@ case class CompilerBuilder() extends ICompilerBuilder:
       headFrame,
       dependencyCompleter,
       whiteList,
-      initialClassLoader
+      initialClassLoader,
+      outputDir
     )
 
 object CompilerBuilder:

--- a/amm/compiler/src/main/scala-3/ammonite/compiler/CompilerExtensions.scala
+++ b/amm/compiler/src/main/scala-3/ammonite/compiler/CompilerExtensions.scala
@@ -3,6 +3,8 @@ package ammonite.compiler
 import ammonite.interp.api.InterpAPI
 import ammonite.repl.api.ReplAPI
 
+import java.nio.file.Path
+
 object CompilerExtensions {
 
   implicit class CompilerInterpAPIExtensions(private val api: InterpAPI) extends AnyVal {
@@ -23,6 +25,14 @@ object CompilerExtensions {
       */
     def preConfigureCompiler(c: dotty.tools.dotc.core.Contexts.FreshContext => Unit): Unit =
       compilerManager.preConfigureCompiler(c)
+
+    /**
+      * Directory where the byte code resulting from compiling the user code is written.
+      * This is non-empty only if the `--output-directory` or `--tmp-output-directory` options
+      * are passed to Ammonite upon launch.
+      */
+    def outputDir: Option[Path] =
+      compilerManager.outputDir
   }
 
   implicit class CompilerReplAPIExtensions(private val api: ReplAPI) extends AnyVal {

--- a/amm/compiler/src/main/scala-3/ammonite/compiler/CompilerLifecycleManager.scala
+++ b/amm/compiler/src/main/scala-3/ammonite/compiler/CompilerLifecycleManager.scala
@@ -29,7 +29,8 @@ class CompilerLifecycleManager(
   headFrame: => ammonite.util.Frame,
   dependencyCompleteOpt: => Option[String => (Int, Seq[String])],
   classPathWhitelist: Set[Seq[String]],
-  initialClassLoader: ClassLoader
+  initialClassLoader: ClassLoader,
+  val outputDir: Option[Path]
 ) extends ammonite.compiler.iface.CompilerLifecycleManager {
 
   def scalaVersion = dotc.config.Properties.versionNumberString
@@ -39,7 +40,8 @@ class CompilerLifecycleManager(
 
 
   private[this] object Internal{
-    val dynamicClasspath = AbstractFile.getDirectory(os.temp.dir().toNIO)
+    outputDir.map(os.Path(_, os.pwd)).foreach(os.makeDir.all(_))
+    val dynamicClasspath = AbstractFile.getDirectory(outputDir.getOrElse(os.temp.dir().toNIO))
     var compiler: ammonite.compiler.Compiler = null
     val onCompilerInit = mutable.Buffer.empty[DottyCompiler => Unit]
     val onSettingsInit = mutable.Buffer.empty[FreshContext => Unit] // TODO Pass a SettingsState too
@@ -148,7 +150,7 @@ class CompilerLifecycleManager(
     }
 
   def addToClasspath(classFiles: ClassFiles): Unit = synchronized {
-    Compiler.addToClasspath(classFiles, dynamicClasspath)
+    Compiler.addToClasspath(classFiles, dynamicClasspath, outputDir)
   }
   def shutdownPressy() = () // N/A in Scala 3
 }

--- a/amm/repl/src/test/scala/ammonite/DualTestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/DualTestRepl.scala
@@ -10,7 +10,7 @@ class DualTestRepl { dual =>
 
   def predef: (String, Option[os.Path]) = ("", None)
 
-  val compilerBuilder = ammonite.compiler.CompilerBuilder()
+  def compilerBuilder = ammonite.compiler.CompilerBuilder()
   val repls = Seq(
     new TestRepl(compilerBuilder) {
       override def predef = dual.predef

--- a/amm/repl/src/test/scala/ammonite/DualTestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/DualTestRepl.scala
@@ -10,7 +10,7 @@ class DualTestRepl { dual =>
 
   def predef: (String, Option[os.Path]) = ("", None)
 
-  val compilerBuilder = ammonite.compiler.CompilerBuilder
+  val compilerBuilder = ammonite.compiler.CompilerBuilder()
   val repls = Seq(
     new TestRepl(compilerBuilder) {
       override def predef = dual.predef

--- a/amm/repl/src/test/scala/ammonite/TestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/TestRepl.scala
@@ -22,7 +22,7 @@ import ammonite.runtime.ImportHook
  * A test REPL which does not read from stdin or stdout files, but instead lets
  * you feed in lines or sessions programmatically and have it execute them.
  */
-class TestRepl(compilerBuilder: ICompilerBuilder = CompilerBuilder) { self =>
+class TestRepl(compilerBuilder: ICompilerBuilder = CompilerBuilder()) { self =>
   def scala2 = compilerBuilder.scalaVersion.startsWith("2.")
   def scalaVersion = compilerBuilder.scalaVersion
 

--- a/amm/repl/src/test/scala/ammonite/TestUtils.scala
+++ b/amm/repl/src/test/scala/ammonite/TestUtils.scala
@@ -38,7 +38,7 @@ object TestUtils {
       classPathWhitelist = ammonite.repl.Repl.getClassPathWhitelist(thin = true)
     )
     val interp = new Interpreter(
-      ammonite.compiler.CompilerBuilder,
+      ammonite.compiler.CompilerBuilder(),
       () => ammonite.compiler.Parsers,
 
       getFrame = () => startFrame,

--- a/amm/src/main/scala/ammonite/AmmoniteMain.scala
+++ b/amm/src/main/scala/ammonite/AmmoniteMain.scala
@@ -62,7 +62,7 @@ object AmmoniteMain{
       case Right(cliConfig) =>
         if (cliConfig.core.bsp.value) {
           val buildServer = new AmmoniteBuildServer(
-            ammonite.compiler.CompilerBuilder,
+            ammonite.compiler.CompilerBuilder(),
             ammonite.compiler.Parsers,
             ammonite.compiler.DefaultCodeWrapper,
             initialScripts = cliConfig.rest.map(os.Path(_)),

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -82,7 +82,7 @@ case class Main(predefCode: String = "",
                 alreadyLoadedDependencies: Seq[Dependency] =
                   Defaults.alreadyLoadedDependencies(),
                 importHooks: Map[Seq[String], ImportHook] = ImportHook.defaults,
-                compilerBuilder: CompilerBuilder = ammonite.compiler.CompilerBuilder,
+                compilerBuilder: CompilerBuilder = ammonite.compiler.CompilerBuilder(),
                 // by-name, so that fastparse isn't loaded when we don't need it
                 parser: () => Parser = () => ammonite.compiler.Parsers,
                 classPathWhitelist: Set[Seq[String]] = Set.empty){

--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -185,7 +185,7 @@ case class Main(predefCode: String = "",
         alreadyLoadedDependencies = alreadyLoadedDependencies
       )
       val interp = new Interpreter(
-        ammonite.compiler.CompilerBuilder,
+        compilerBuilder,
         () => parser0,
         () => frame,
         () => throw new Exception("session loading / saving not possible here"),

--- a/amm/src/main/scala/ammonite/MainRunner.scala
+++ b/amm/src/main/scala/ammonite/MainRunner.scala
@@ -139,8 +139,14 @@ class MainRunner(cliConfig: Config,
       parser = () => parser,
       alreadyLoadedDependencies =
         Defaults.alreadyLoadedDependencies(),
-      classPathWhitelist = ammonite.repl.Repl.getClassPathWhitelist(cliConfig.core.thin.value)
-
+      classPathWhitelist = ammonite.repl.Repl.getClassPathWhitelist(cliConfig.core.thin.value),
+      compilerBuilder = ammonite.compiler.CompilerBuilder(
+        outputDir = cliConfig.repl.outputDirectory.map(_.toNIO)
+          .orElse {
+            if (cliConfig.repl.tmpOutputDirectory.value) Some(os.temp.dir(prefix = "ammonite-output").toNIO)
+            else None
+          }
+      )
     )
   }
 

--- a/amm/src/main/scala/ammonite/main/Config.scala
+++ b/amm/src/main/scala/ammonite/main/Config.scala
@@ -91,7 +91,19 @@ object Config{
       doc =
         "Wrap user code in classes rather than singletons, typically for Java serialization "+
         "friendliness.")
-    classBased: Flag
+    classBased: Flag,
+    @arg(
+      name = "output-directory",
+      doc = """Write byte code of the user code in a directory.
+        The path of that directory can also be accessed later on from the REPL via 'interp.outputDir'.""")
+    outputDirectory: Option[os.Path] = None,
+    @arg(
+      name = "tmp-output-directory",
+      doc = """Write byte code of the user code in a temporary directory, created by Ammonite.
+        You can access get that directory later on via 'interp.outputDir'.
+        That directory is deleted by Ammonite upon exit. Use --output-directory if you'd like
+        the output directory not to be erased.""")
+    tmpOutputDirectory: Flag
   )
   implicit val replParser = ParserForClass[Repl]
 

--- a/amm/src/test/scala/ammonite/interp/script/AmmoniteBuildServerTests.scala
+++ b/amm/src/test/scala/ammonite/interp/script/AmmoniteBuildServerTests.scala
@@ -688,7 +688,7 @@ object AmmoniteBuildServerTests extends TestSuite {
       this(wd, script)
 
     val server = new AmmoniteBuildServer(
-      ammonite.compiler.CompilerBuilder,
+      ammonite.compiler.CompilerBuilder(),
       ammonite.compiler.Parsers,
       ammonite.compiler.DefaultCodeWrapper,
       initialScripts = script


### PR DESCRIPTION
This adds an `--output-directory` option equivalent to `-Yrepl-outdir` in the default Scala REPL. The latter is [used by the Spark REPL](https://github.com/apache/spark/blob/156a12ec0abba8362658a58e00179a0b80f663f2/repl/src/main/scala-2.12/org/apache/spark/repl/Main.scala#L70) in particular, and I'm planning to use that new option in Spark-related developments (in [ammonite-spark](https://github.com/alexarchambault/ammonite-spark), itself used by [Almond](https://github.com/almond-sh/almond)).

This option basically writes in the passed directory the byte code generated by compiling the user code.