### PR TITLE
Be fine with non-existent files in class path in Scala 2

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -794,8 +794,14 @@ class IntegrationModule(val crossScalaVersion: String) extends AmmInternalModule
       Agg.empty
   }
   object test extends Tests {
+    def testLauncher = T {
+      if (scala.util.Properties.isWin)
+        amm().launcher().path.toString
+      else
+        amm().assembly().path.toString
+    }
     def forkEnv = super.forkEnv() ++ Seq(
-      "AMMONITE_ASSEMBLY" -> amm().launcher().path.toString
+      "AMMONITE_ASSEMBLY" -> testLauncher()
     )
   }
 }

--- a/integration/src/test/scala/ammonite/integration/BasicTests.scala
+++ b/integration/src/test/scala/ammonite/integration/BasicTests.scala
@@ -3,6 +3,8 @@ package ammonite.integration
 import utest._
 import ammonite.util.Util
 import TestUtils._
+
+import java.io.File
 /**
  * Run a small number of scripts using the Ammonite standalone executable,
  * to make sure that this works. Otherwise it tends to break since the
@@ -298,6 +300,12 @@ object BasicTests extends TestSuite{
       assert(res.exitCode == 1)
       val output = res.out.lines()
       assert(output.contains("""Exception in thread "main" java.lang.Exception: from predef"""))
+    }
+
+    test("missing JAR") {
+      val cp = Seq(TestUtils.ammAssembly, "/foo/b.jar").mkString(File.pathSeparator)
+      os.proc("java", "-cp", cp, "ammonite.AmmoniteMain", "--predef-code", """println("Hello"); sys.exit(0)""")
+        .call()
     }
   }
 }

--- a/integration/src/test/scala/ammonite/integration/BasicTests.scala
+++ b/integration/src/test/scala/ammonite/integration/BasicTests.scala
@@ -291,5 +291,13 @@ object BasicTests extends TestSuite{
       )
       assert(res.exitCode == 0)
     }
+
+    test("predef throws") {
+      val res = os.proc(TestUtils.executable, "--predef-code", """throw new Exception("from predef")""")
+        .call(check = false, mergeErrIntoOut = true)
+      assert(res.exitCode == 1)
+      val output = res.out.lines()
+      assert(output.contains("""Exception in thread "main" java.lang.Exception: from predef"""))
+    }
   }
 }

--- a/integration/src/test/scala/ammonite/integration/TestUtils.scala
+++ b/integration/src/test/scala/ammonite/integration/TestUtils.scala
@@ -10,13 +10,12 @@ object TestUtils {
   val isScala2 = scalaVersion.startsWith("2.")
   val javaVersion = scala.util.Properties.javaVersion
   val ammVersion = ammonite.Constants.version
-  val executable = {
-    val p = System.getenv("AMMONITE_ASSEMBLY")
+  val ammAssembly = System.getenv("AMMONITE_ASSEMBLY")
+  val executable =
     if (Util.windowsPlatform)
-      Seq(p)
+      Seq(ammAssembly)
     else
-      Seq("bash", p)
-  }
+      Seq("bash", ammAssembly)
   val intTestResources = os.pwd/'integration/'src/'test/'resources
   val replStandaloneResources = intTestResources/'ammonite/'integration
   val shellAmmoniteResources = os.pwd/'shell/'src/'main/'resources/'ammonite/'shell


### PR DESCRIPTION
This is a problem when launching Ammonite with a manual `java -cp` command, and adding JARs alongside it. If some of those JARs don't exist, Ammonite currently crashes (fails to compile anything with a stacktrace, or prints a stacktrace and exit if there's a predef). This PR fixes that.