### PR TITLE
doc: Fix incorrect mention of Scala 2.12 being latest

### DIFF
--- a/readme/Footer.scalatex
+++ b/readme/Footer.scalatex
@@ -24,7 +24,7 @@
   @sect{Older Scala Versions}
     @p
       While most people would be using Ammonite for the latest version of Scala,
-      2.12, Ammonite also provides standalone executables for older versions of
+      3.2, Ammonite also provides standalone executables for older versions of
       Scala:
 
     @for(versionNameLink <- ammonite.Constants.oldCurlUrls)


### PR DESCRIPTION
So, I noticed that the documentation contains a strange phrase, saying that the latest version of Scala is 2.12.
This is a few versions out of date! I've fixed it here.

However I think it's also worth you taking a look at the older versions listed, as currently it's just showing up a 2.12 version, and I think you have a 2.13 version around too?