### PR TITLE
Accept files paths and more refined class paths in 'import $cp'

### DIFF
--- a/amm/repl/src/test/scala/ammonite/DualTestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/DualTestRepl.scala
@@ -22,6 +22,9 @@ class DualTestRepl { dual =>
   )
 
   def scalaVersion = compilerBuilder.scalaVersion
+  lazy val scalaBinaryVersion =
+    if (scalaVersion.startsWith("2.")) scalaVersion.split('.').take(2).mkString(".")
+    else scalaVersion.takeWhile(_ != '.')
   def scala2 = scalaVersion.startsWith("2.")
   def scala2_12 = scalaVersion.startsWith("2.12.")
 

--- a/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
@@ -3,6 +3,7 @@ package ammonite.session
 import ammonite.{DualTestRepl, TestUtils}
 import utest._
 
+import scala.collection.JavaConverters._
 import scala.collection.{immutable => imm}
 object BuiltinTests extends TestSuite{
 
@@ -83,6 +84,24 @@ object BuiltinTests extends TestSuite{
 
         @ hello.Hello.hello()
         res5: String = "Hello!"
+      """)
+    }
+    test("importCp") {
+      val catsCp = coursierapi.Fetch.create()
+        .addDependencies(coursierapi.Dependency.of("org.typelevel", "cats-core_" + check.scalaBinaryVersion, "2.9.0"))
+        .fetch()
+        .asScala
+        .map(os.Path(_, os.pwd))
+      val tmpDir = os.temp.dir(prefix = "amm-builtin-tests")
+      for (f <- catsCp)
+        os.copy.into(f, tmpDir)
+      check.session(s"""
+        @ sys.props("the.tmp.dir") = "${tmpDir.toString.replace("\\", "\\\\")}"
+
+        @ import $$cp.`$${the.tmp.dir}/*`
+
+        @ import cats.Monoid
+        import cats.Monoid
       """)
     }
     test("settings"){

--- a/amm/runtime/src/main/scala/ammonite/runtime/ImportHook.scala
+++ b/amm/runtime/src/main/scala/ammonite/runtime/ImportHook.scala
@@ -1,6 +1,6 @@
 package ammonite.runtime
 
-import java.io.{ByteArrayOutputStream, File}
+import java.io.{ByteArrayOutputStream, File => JFile}
 import java.net.URI
 
 import ammonite.interp.api.IvyConstructor
@@ -52,7 +52,7 @@ object ImportHook{
     * default this is what is available.
     */
   trait InterpreterInterface {
-    def loadIvy(coordinates: Dependency*): Either[String, Seq[File]]
+    def loadIvy(coordinates: Dependency*): Either[String, Seq[JFile]]
     def watch(p: os.Path): Unit
     def scalaVersion: String
   }
@@ -175,7 +175,7 @@ object ImportHook{
     def resolve(
       interp: InterpreterInterface,
       signatures: Seq[String]
-    ): Either[String, (Seq[Dependency], Seq[File])] = {
+    ): Either[String, (Seq[Dependency], Seq[JFile])] = {
       val splitted = for (signature <- signatures) yield {
         val (dottyCompat, coords) =
           if (signature.endsWith(" compat")) (true, signature.stripSuffix(" compat"))

--- a/build.sc
+++ b/build.sc
@@ -82,6 +82,7 @@ object Deps {
   val bsp4j = ivy"ch.epfl.scala:bsp4j:${bspVersion}"
   val bcprovJdk15on = ivy"org.bouncycastle:bcprov-jdk15on:1.56"
   val cask = ivy"com.lihaoyi::cask:0.6.0"
+  val classPathUtil = ivy"io.get-coursier::class-path-util:0.1.2"
   val coursierInterface = ivy"io.get-coursier:interface:1.0.13"
   val fastparse = ivy"com.lihaoyi::fastparse:$fastparseVersion"
   val geny = ivy"com.lihaoyi::geny:1.0.0"
@@ -415,6 +416,7 @@ object amm extends Cross[MainModule](fullCrossScalaVersions:_*){
     def moduleDeps = Seq(amm.util(), interp.api(), amm.repl.api())
     def crossFullScalaVersion = true
     def ivyDeps = Agg(
+      Deps.classPathUtil,
       Deps.upickle,
       Deps.requests,
       Deps.mainargs.use_3(crossScalaVersion)

--- a/readme/Repl.scalatex
+++ b/readme/Repl.scalatex
@@ -446,6 +446,14 @@
           See the docs for @sect.ref{Scala Scripts} for more on how script
           files work in general.
 
+      @sect{import $cp}
+        @p
+          Lets you add files in the class path. It uses the same syntax
+          as $sect.ref{import $file}, like
+
+        @hl.scala
+          @@ import $cp.^.scripts.foo // adds ../scripts/foo to the class path
+
       @sect{import $ivy}
         @p
           Lets you import Ivy dependencies from Maven Central, or anywhere else.

--- a/readme/Repl.scalatex
+++ b/readme/Repl.scalatex
@@ -448,11 +448,33 @@
 
       @sect{import $cp}
         @p
-          Lets you add files in the class path. It uses the same syntax
+          Lets you add files in the class path. You can use either the same syntax
           as $sect.ref{import $file}, like
 
         @hl.scala
           @@ import $cp.^.scripts.foo // adds ../scripts/foo to the class path
+
+        @p
+          Or you can pass file paths between back-ticks, like
+
+        @hl.scala
+          @@ import $cp.`../scripts/foo.jar` // adds ../scripts/foo.jar to the class path
+
+        @p
+          @code{*} are also accepted after directory paths, Java properties can be substituted
+          in values passed to @hl.scala{import $cp}, and several values can be passed, provided
+          they're separated by the standard path separator (@code{;} on Linux and macOS, and
+          @code{:} on Windows)
+
+        @hl.scala
+          @@ import $cp.`${spark.home}/jars/*` // adds all JARs under the jars subdirectory of Spark home
+
+        @p
+          Ammonite disambiguates the two syntaxes above the following way: if the import consists in a
+          single element after @hl.scala{import $cp.}, and this element contains @code{/} (on all platforms),
+          or the local PATH separator (@code{;} on Windows, @code{:} on Linux and macOS), or
+          a @code{\} if on Windows, then the second syntax above is assumed (class path syntax). Else,
+          the first syntax is assumed.
 
       @sect{import $ivy}
         @p


### PR DESCRIPTION
See the added documentation. This makes the following work, while not breaking today's `import $cp` syntax:
```scala
@ import $cp.`/foo/a/b.jar`
@ import $cp.`/foo/a/b.jar;/foo/a/c.jar;/foo/a/d.jar`
@ import $cp.`/foo/a/*`
@ import $cp.`../foo/a/*`
@ import $cp.`${the.foo.dir}/a/*`
```

That syntax makes it easier to add elements to the class path using `import $cp`, when one gets these paths via another tool: one doesn't have to convert it to `import $cp.^.^.^.foo.a.b`. And it also:
- substitutes Java properties
- accepts multiple elements separated by `;` (Linux / macOS) or `:` (Windows)
- accepts some blobs to add all JARs in a directory

This relies on [a library](https://github.com/coursier/class-path-util) recently added in then spin off from coursier. The `--extra-jar` option of `cs launch` uses it too. I'm planning to propose to have Scala CLI accept it at various places too.