### PR TITLE
Fix code completion breaking after wildcard import

### DIFF
--- a/amm/repl/src/main/scala/ammonite/repl/Repl.scala
+++ b/amm/repl/src/main/scala/ammonite/repl/Repl.scala
@@ -177,7 +177,9 @@ class Repl(input: InputStream,
 
       case ex => Res.Exception(ex, "")
     }
-
+    // workaround to wildcard imports breaking code completion, see
+    // https://github.com/com-lihaoyi/Ammonite/issues/1009
+    importsForCompletion = Imports(fullImports.value.filter(_.fromName.raw != "package"))
     _ <- Signaller("INT") {
       // Put a fake `ThreadDeath` error in `lastException`, because `Thread#stop`
       // raises an error with the stack trace of *this interrupt thread*, rather
@@ -192,7 +194,7 @@ class Repl(input: InputStream,
       output,
       colors().prompt()(prompt()).render,
       colors(),
-      interp.compilerManager.complete(_, fullImports.toString, _),
+      interp.compilerManager.complete(_, importsForCompletion.toString, _),
       storage.fullHistory(),
       addHistory = (code) => if (code != "") {
         storage.fullHistory() = storage.fullHistory() :+ code

--- a/amm/repl/src/test/scala/ammonite/interp/ReplTests.scala
+++ b/amm/repl/src/test/scala/ammonite/interp/ReplTests.scala
@@ -1,0 +1,69 @@
+package ammonite.interp
+
+import ammonite.compiler.{CompilerBuilder, DefaultCodeWrapper}
+import ammonite.main.Defaults
+import ammonite.repl.Repl
+import ammonite.runtime.{ImportHook, Storage}
+import ammonite.util._
+import utest._
+
+import java.io.{ByteArrayInputStream}
+import java.nio.charset.StandardCharsets
+
+object ReplTests extends TestSuite {
+  val tempDir = os.Path(
+    java.nio.file.Files.createTempDirectory("ammonite-tester")
+  )
+
+  def runInRepl(code: String): (String, String) = {
+    val stdoutBuilder = new StringBuilder()
+    val stderrBuilder = new StringBuilder()
+    val repl = new Repl(
+      input = new ByteArrayInputStream(code.getBytes(StandardCharsets.UTF_8)),
+      output = (b: Int) => stdoutBuilder.append(b.toChar),
+      error = (b: Int) => stderrBuilder.append(b.toChar),
+      storage = new Storage.Folder(tempDir),
+      baseImports = ammonite.main.Defaults.replImports ++ Interpreter.predefImports,
+      basePredefs = Seq(
+        PredefInfo(Name("testPredef"), "", false, None)
+      ),
+      customPredefs = Seq(),
+      wd = os.pwd,
+      welcomeBanner = None,
+      replCodeWrapper = DefaultCodeWrapper,
+      scriptCodeWrapper = DefaultCodeWrapper,
+      alreadyLoadedDependencies = Defaults.alreadyLoadedDependencies(),
+      importHooks = ImportHook.defaults,
+      compilerBuilder = CompilerBuilder(),
+      parser = ammonite.compiler.Parsers,
+      initialColors = Colors.BlackWhite,
+      classPathWhitelist = ammonite.repl.Repl.getClassPathWhitelist(thin = true)
+    )
+    repl.initializePredef()
+    repl.run()
+
+    (stdoutBuilder.toString(), stderrBuilder.toString())
+  }
+
+  override val tests = Tests {
+    println("ReplTests")
+
+    test("Simple complete") {
+      val (stdout, _) = runInRepl("prin\t")
+      Seq("print", "printf", "println").foreach { str =>
+        assert(stdout.contains(str))
+      }
+      assert(!stdout.contains("javax.print"))
+    }
+    test("Complete with wildcard imports") {
+      // Code completion used to break after a wildcard import
+      // https://github.com/com-lihaoyi/Ammonite/issues/1009
+      val (stdout, _) = runInRepl("import sys.process._\nprin\t")
+      Seq("print", "printf", "println").foreach { str =>
+        assert(stdout.contains(str))
+        // some wrong completion item which used to show up when completion was broken
+        assert(!stdout.contains("javax.print"))
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes an issue when code completion breaks after a wildcard import (see https://github.com/com-lihaoyi/Ammonite/issues/1009 for more details). It's solved by removing ```package```  import item from imports string passed to completer.

To test this, I added a new `ReplTests` suite which instantiates a Repl and feeds it a user input string which may consist of a several commands. The existing unit tests (`AutocompleteTests` in particular) cannot be used to verify this fix, as they use `TestRepl` instead of `Repl` which duplicates code completion logics.