### PR TITLE
Fix line numbers in exceptions for multi-line code blocks

### DIFF
--- a/amm/compiler/src/main/scala-2/ammonite/compiler/Parsers.scala
+++ b/amm/compiler/src/main/scala-2/ammonite/compiler/Parsers.scala
@@ -65,6 +65,8 @@ object Parsers extends IParser {
 
   private def Splitter0[_: P] = P(StatementBlock(Fail))
 
+  private def HighlightSplitter[_: P] = P( ("{" ~ Splitter0 ~ "}" | Splitter0) ~ End )
+
   def Splitter[_: P] = P(("{" ~~ WL.! ~~ Splitter0 ~ "}" | WL.! ~~ Splitter0) ~ End)
 
   private def ObjParser[_: P] = P( ObjDef )
@@ -98,7 +100,7 @@ object Parsers extends IParser {
         case Parsed.Success(value, index) => {
           val (str, seq) = value
           if (seq.isEmpty) {
-            Some(Right(Seq(str)))
+            Some(Right(Nil))
           } else {
             Some(Right(Seq(str + seq.head._2) ++ seq.tail.map(_._2)))
           }
@@ -112,7 +114,7 @@ object Parsers extends IParser {
         case Parsed.Success(value, index) => {
           val (str, seq) = value
           if (seq.isEmpty) {
-            Some(Right(Seq(str)))
+            Some(Right(Nil))
           } else {
             Some(Right(Seq(str + seq.head._2) ++ seq.tail.map(_._2)))
           }
@@ -281,7 +283,7 @@ object Parsers extends IParser {
                        keyword: fansi.Attrs,
                        notImplemented: fansi.Attrs,
                        reset: fansi.Attrs) = {
-    Highlighter.defaultHighlight0(Splitter(_), buffer, comment, `type`, literal, keyword, reset)
+    Highlighter.defaultHighlight0(HighlightSplitter(_), buffer, comment, `type`, literal, keyword, reset)
   }
   def defaultHighlightIndices(buffer: Vector[Char],
                               comment: fansi.Attrs,
@@ -289,11 +291,11 @@ object Parsers extends IParser {
                               literal: fansi.Attrs,
                               keyword: fansi.Attrs,
                               reset: fansi.Attrs) = Highlighter.defaultHighlightIndices0(
-    Splitter(_), buffer, comment, `type`, literal, keyword, reset
+    HighlightSplitter(_), buffer, comment, `type`, literal, keyword, reset
   )
 
   def highlightIndices[T](buffer: Vector[Char],
                           ruleColors: PartialFunction[String, T],
                           endColor: T): Seq[(Int, T)] =
-    Highlighter.highlightIndices(Parsers.Splitter(_), buffer, ruleColors, endColor)
+    Highlighter.highlightIndices(Parsers.HighlightSplitter(_), buffer, ruleColors, endColor)
 }

--- a/amm/repl/src/test/scala/ammonite/session/FailureTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/FailureTests.scala
@@ -77,5 +77,29 @@ object FailureTests extends TestSuite{
         !x.contains("Something unexpected went wrong =(")
       )
     }
+
+    test("lineNumbersInStackTrace1") {
+      check.fail("""
+        |
+        |
+        | 1 / 0
+        |""".stripMargin, x =>
+        x.contains("/ by zero") &&
+        x.contains("cmd0.sc:4") // check that the line number is correct
+      )
+    }
+
+    test("lineNumbersInStackTrace2") {
+      check.fail("""
+        |{
+        |
+        | // block command
+        | 1 / 0
+        |}
+        |""".stripMargin, x =>
+        x.contains("/ by zero") &&
+        x.contains("cmd0.sc:5") // check that the line number is correct
+      )
+    }
   }
 }

--- a/amm/repl/src/test/scala/ammonite/session/FailureTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/FailureTests.scala
@@ -79,27 +79,34 @@ object FailureTests extends TestSuite{
     }
 
     test("lineNumbersInStackTrace1") {
-      check.fail("""
-        |
-        |
-        | 1 / 0
-        |""".stripMargin, x =>
-        x.contains("/ by zero") &&
-        x.contains("cmd0.sc:4") // check that the line number is correct
-      )
+      if (check.scala2) {
+        check.fail(
+          """
+            |
+            |
+            | 1 / 0
+            |""".stripMargin, x =>
+            x.contains("/ by zero") &&
+            x.contains("cmd0.sc:4") // check that the line number is correct
+
+        )
+      }
     }
 
     test("lineNumbersInStackTrace2") {
-      check.fail("""
-        |{
-        |
-        | // block command
-        | 1 / 0
-        |}
-        |""".stripMargin, x =>
-        x.contains("/ by zero") &&
-        x.contains("cmd0.sc:5") // check that the line number is correct
-      )
+      if (check.scala2) {
+        check.fail(
+        """
+          |{
+          |
+          | // block command
+          | 1 / 0
+          |}
+          |""".stripMargin, x =>
+          x.contains("/ by zero") &&
+          x.contains("cmd0.sc:5") // check that the line number is correct
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
## What is changed?
The current Parser ignores whitespaces at the beginning of the code block, which may result in incorrect line number in an exception stackTrace:
```
@ {
  
  
  1 / 0
  } 
java.lang.ArithmeticException: / by zero
  ammonite.$sess.cmd0$.<init>(cmd0.sc:1)
  ammonite.$sess.cmd0$.<clinit>(cmd0.sc)
```

This PR changes it so the result will be
```
@ { 
  
  
  1 / 0
  } 
java.lang.ArithmeticException: / by zero
  ammonite.$sess.cmd0$.<init>(cmd0.sc:4)
  ammonite.$sess.cmd0$.<clinit>(cmd0.sc)

```
(line number is 4 instead of 1)

This it done by introducing a new parser which does not ignore leading whitespaces


Please note that it changes this only for Scala 2. Scala 3 impl has a different parsing logics which I didn't have time to dive into yet
## How is it tested?
New tests in `FailureTests` checking line numbers