### PR TITLE
Fix recent regression with comments right before imports

### DIFF
--- a/amm/compiler/src/main/scala-2/ammonite/compiler/DefaultPreprocessor.scala
+++ b/amm/compiler/src/main/scala-2/ammonite/compiler/DefaultPreprocessor.scala
@@ -111,8 +111,13 @@ class DefaultPreprocessor(parse: => String => Either[String, Seq[G#Tree]],
 
   val Import = Processor{
     case (name, code, tree: G#Import) =>
-      val Array(keyword, body) = code.split(" ", 2)
-      val tq = "\"\"\""
+      val body = fastparse.parse(code, Parsers.ImportFinder(_)) match {
+        case s: fastparse.Parsed.Success[String] =>
+          s.value
+        case _ =>
+          val Array(keyword, body) = code.split(" ", 2)
+          body
+      }
       Expanded(code, Seq(
         s"""
         _root_.ammonite

--- a/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -695,5 +695,18 @@ object AdvancedTests extends TestSuite{
       val files = os.walk(dir).filter(os.isFile(_)).map(_.relativeTo(dir))
       assert(files.sorted == expectedFiles.sorted)
     }
+    test("comment and import") {
+      check.session(
+        """
+          @ import $ivy.`org.typelevel::cats-kernel:2.6.1`
+
+          @ {
+          @   // hello
+          @   import cats.kernel._
+          @ }
+          import cats.kernel._
+        """
+      )
+    }
   }
 }


### PR DESCRIPTION
This fixes a recent regression when a comment precedes an import in a code block, like
```
@ {
    // hello
    import cats.kernel._
  }
```

(introduced in https://github.com/com-lihaoyi/Ammonite/pull/1361, that fixes nice things otherwise)

Before this PR, ones gets:
```text
Welcome to the Ammonite Repl 3.0.0-M0-33-94c5ce87 (Scala 2.13.11 Java 1.8.0_362)
@ import $ivy.`org.typelevel::cats-kernel:2.6.1`
import $ivy.$

@ {
  // hello
  import cats.kernel._
  }
import hello
import cats.kernel._
```
(note the `import hello` towards the end)

With this PR, we get the expected output at the end:
```text
Welcome to the Ammonite Repl 3.0.0-M0-35-3a5444f1 (Scala 2.13.11 Java 1.8.0_362)
@ import $ivy.`org.typelevel::cats-kernel:2.6.1`
import $ivy.$

@ {
  // hello
  import cats.kernel._
  }
import cats.kernel._
```