### PR TITLE
Factor wrapper name in Interpreter

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -232,7 +232,7 @@ class Interpreter(val compilerBuilder: CompilerBuilder,
                   silent: Boolean = false,
                   incrementLine: () => Unit): Res[Evaluated] = synchronized{
 
-    val wrapperName = Name("cmd" + currentLine)
+    val wrapperName = Name(wrapperNamePrefix + currentLine)
 
     val codeSource = CodeSource(
       wrapperName,
@@ -422,7 +422,7 @@ class Interpreter(val compilerBuilder: CompilerBuilder,
   def processExec(code: String,
                   currentLine: Int,
                   incrementLine: () => Unit): Res[Imports] = synchronized{
-    val wrapperName = Name("cmd" + currentLine)
+    val wrapperName = Name(wrapperNamePrefix + currentLine)
     val fileName = wrapperName.encoded + ".sc"
     for {
       blocks <- Res(parser().splitScript(Interpreter.skipSheBangLine(code), fileName))
@@ -712,6 +712,10 @@ class Interpreter(val compilerBuilder: CompilerBuilder,
 
 object Interpreter{
 
+  /** @param wrapperNamePrefix
+    *   Name to be used as a prefix for source file and classes wrapping user code, that ends in
+    *   compilation errors or stack traces in particular
+    */
   case class Parameters(
     printer: Printer = Printer(
       System.out,
@@ -728,7 +732,8 @@ object Interpreter{
     initialClassLoader: ClassLoader = null,
     importHooks: Map[Seq[String], ImportHook] = ImportHook.defaults,
     alreadyLoadedDependencies: Seq[Dependency] = Nil,
-    classPathWhitelist: Set[Seq[String]] = Set.empty
+    classPathWhitelist: Set[Seq[String]] = Set.empty,
+    wrapperNamePrefix: String = "cmd"
   )
 
   val predefImports = Imports(

--- a/amm/repl/src/test/scala/ammonite/DualTestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/DualTestRepl.scala
@@ -9,15 +9,18 @@ import ammonite.util.{Evaluated, Res}
 class DualTestRepl { dual =>
 
   def predef: (String, Option[os.Path]) = ("", None)
+  def wrapperNamePrefix = Option.empty[String]
 
   def compilerBuilder = ammonite.compiler.CompilerBuilder()
   val repls = Seq(
     new TestRepl(compilerBuilder) {
       override def predef = dual.predef
+      override def wrapperNamePrefix = dual.wrapperNamePrefix
     },
     new TestRepl(compilerBuilder) {
       override def predef = dual.predef
       override def codeWrapper = CodeClassWrapper
+      override def wrapperNamePrefix = dual.wrapperNamePrefix
     }
   )
 

--- a/amm/repl/src/test/scala/ammonite/TestRepl.scala
+++ b/amm/repl/src/test/scala/ammonite/TestRepl.scala
@@ -29,6 +29,7 @@ class TestRepl(compilerBuilder: ICompilerBuilder = CompilerBuilder()) { self =>
   var allOutput = ""
   def predef: (String, Option[os.Path]) = ("", None)
   def codeWrapper: CodeWrapper = DefaultCodeWrapper
+  def wrapperNamePrefix = Option.empty[String]
 
   val tempDir = os.Path(
     java.nio.file.Files.createTempDirectory("ammonite-tester")
@@ -77,7 +78,8 @@ class TestRepl(compilerBuilder: ICompilerBuilder = CompilerBuilder()) { self =>
     initialClassLoader = initialClassLoader,
     alreadyLoadedDependencies = Defaults.alreadyLoadedDependencies("amm-test-dependencies.txt"),
     importHooks = ImportHook.defaults,
-    classPathWhitelist = ammonite.repl.Repl.getClassPathWhitelist(thin = true)
+    classPathWhitelist = ammonite.repl.Repl.getClassPathWhitelist(thin = true),
+    wrapperNamePrefix = wrapperNamePrefix.getOrElse(Interpreter.Parameters().wrapperNamePrefix)
   )
   val interp = try {
     new Interpreter(

--- a/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -759,5 +759,18 @@ object AdvancedTests extends TestSuite{
           """
       )
     }
+
+    test("custom wrapper name prefix") {
+      val check = new DualTestRepl {
+        override def wrapperNamePrefix = Some("cell")
+      }
+      // Helper suffix stripped for class-based code wrapping
+      check.session(
+        """
+          @ val clsName = getClass.getName.stripPrefix("ammonite.$sess.").stripSuffix("Helper")
+          clsName: String = "cell0$"
+        """
+      )
+    }
   }
 }

--- a/amm/repl/src/test/scala/ammonite/session/FailureTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/FailureTests.scala
@@ -108,5 +108,23 @@ object FailureTests extends TestSuite{
         )
       }
     }
+
+    test("wrapperNameInStackTrace") {
+      val check = new DualTestRepl {
+        override def wrapperNamePrefix = Some("cell")
+      }
+      check.fail(
+        """{
+          |
+          | // block command
+          | 1 / 0
+          |}
+          |""".stripMargin,
+        x =>
+          x.contains("/ by zero") &&
+          !x.contains("cmd0.sc:") &&
+          x.contains("cell0.sc:")
+      )
+    }
   }
 }


### PR DESCRIPTION
This allows users of Ammonite as a library to customize the wrapper name used to wrap code for one more adapted to their context (in [Almond](https://github.com/almond-sh/almond), this allows to use `cell` rather than `cmd` - the former makes more sense in notebooks where Almond is used)