### PR TITLE
Make Interpreter#interApi public

### DIFF
--- a/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
+++ b/amm/interp/src/main/scala/ammonite/interp/Interpreter.scala
@@ -656,7 +656,7 @@ class Interpreter(val compilerBuilder: CompilerBuilder,
   }
 
 
-  private[this] lazy val interpApi: InterpAPI = new InterpAPI{ outer =>
+  lazy val interpApi: InterpAPI = new InterpAPI{ outer =>
 
     val colors = parameters.colors
 


### PR DESCRIPTION
This allows users of Ammonite-as-a-library to do things like
```scala
import ammonite.compiler.CompilerExtensions._
interp.interpApi.preConfigureCompiler(???)
```
to add / configure scalac options via the API