### PR TITLE
Overwrite things when copying compiler products in directory

### DIFF
--- a/amm/compiler/src/main/scala-2/ammonite/compiler/Compiler.scala
+++ b/amm/compiler/src/main/scala-2/ammonite/compiler/Compiler.scala
@@ -56,11 +56,8 @@ object Compiler{
       output.write(bytes)
       output.close()
 
-      for (dir <- outputDir0) {
-        val dest = dir / elems
-        os.makeDir.all(dest / os.up)
-        os.write(dest, bytes)
-      }
+      for (dir <- outputDir0)
+        os.write.over(dir / elems, bytes, createFolders = true)
     }
 
   }

--- a/amm/compiler/src/main/scala-3/ammonite/compiler/Compiler.scala
+++ b/amm/compiler/src/main/scala-3/ammonite/compiler/Compiler.scala
@@ -507,11 +507,8 @@ object Compiler:
       output.write(bytes)
       output.close()
 
-      for (dir <- outputDir0) {
-        val dest = dir / elems
-        os.makeDir.all(dest / os.up)
-        os.write(dest, bytes)
-      }
+      for (dir <- outputDir0)
+        os.write.over(dir / elems, bytes, createFolders = true)
     }
 
   }


### PR DESCRIPTION
I've been seeing weird `FileAlreadyExistsException`-s with `metadata.json` files, from Almond. With caching of things via `Storage.Folder` involved…

```
java.nio.file.FileAlreadyExistsException: /var/folders/nh/1smqz1yx5c930wqsx6w7crrh0000gn/T/almond-output7192041737362156701/metadata.json
    sun.nio.fs.UnixException.translateToIOException(UnixException.java:88)
    sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
    sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
    sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:214)
    java.nio.file.Files.newByteChannel(Files.java:361)
    os.write$.write(ReadWriteOps.scala:64)
    os.write$.apply(ReadWriteOps.scala:77)
    ammonite.compiler.Compiler$.addToClasspath$$anonfun$2$$anonfun$1(Compiler.scala:519)
    scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
    scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
    scala.Option.foreach(Option.scala:437)
    ammonite.compiler.Compiler$.addToClasspath$$anonfun$2(Compiler.scala:520)
    scala.runtime.function.JProcedure1.apply(JProcedure1.java:15)
    scala.runtime.function.JProcedure1.apply(JProcedure1.java:10)
    scala.collection.IterableOnceOps.foreach(IterableOnce.scala:576)
    scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:574)
    scala.collection.AbstractIterable.foreach(Iterable.scala:933)
    scala.collection.IterableOps$WithFilter.foreach(Iterable.scala:903)
    ammonite.compiler.Compiler$.addToClasspath(Compiler.scala:521)
    ammonite.compiler.CompilerLifecycleManager.addToClasspath(CompilerLifecycleManager.scala:153)
    ammonite.interp.Interpreter.$anonfun$processAllScriptBlocks$9(Interpreter.scala:564)
    scala.Option$WithFilter.map(Option.scala:242)
    ammonite.interp.Interpreter.loop$1(Interpreter.scala:548)
    ammonite.interp.Interpreter.processAllScriptBlocks(Interpreter.scala:615)
    ammonite.interp.Interpreter.$anonfun$processModule$6(Interpreter.scala:410)
    ammonite.util.Catching.flatMap(Res.scala:115)
    ammonite.interp.Interpreter.$anonfun$processModule$5(Interpreter.scala:401)
    ammonite.util.Res$Success.flatMap(Res.scala:62)
    ammonite.interp.Interpreter.processModule(Interpreter.scala:391)
    ammonite.interp.Interpreter.$anonfun$initializePredef$3(Interpreter.scala:142)
    ammonite.interp.Interpreter.$anonfun$initializePredef$3$adapted(Interpreter.scala:142)
    ammonite.interp.PredefInitialization$.$anonfun$apply$2(PredefInitialization.scala:79)
    ammonite.util.Res$.$anonfun$fold$1(Res.scala:32)
    scala.collection.LinearSeqOps.foldLeft(LinearSeq.scala:183)
    scala.collection.LinearSeqOps.foldLeft$(LinearSeq.scala:179)
    scala.collection.immutable.List.foldLeft(List.scala:79)
    ammonite.util.Res$.fold(Res.scala:30)
    ammonite.interp.PredefInitialization$.apply(PredefInitialization.scala:67)
    ammonite.interp.Interpreter.initializePredef(Interpreter.scala:144)
    almond.amm.AmmInterpreter$.apply(AmmInterpreter.scala:210)
    almond.ScalaInterpreter.ammInterp$lzyINIT1(ScalaInterpreter.scala:138)
    almond.ScalaInterpreter.ammInterp(ScalaInterpreter.scala:110)
    almond.ScalaInterpreter.<init>(ScalaInterpreter.scala:148)
    almond.ScalaInterpreterTests$Predef$.simple(ScalaInterpreterTests.scala:55)
    almond.ScalaInterpreterTests$.$init$$$anonfun$1$$anonfun$3$$anonfun$1(ScalaInterpreterTests.scala:267)
```