### PR TITLE
scalameta: 4.7.8 → 4.8.5

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -77,7 +77,7 @@ val (buildVersion, unstable) = scala.util.Try(
 
 val bspVersion = "2.0.0-M6"
 val fastparseVersion = "3.0.0"
-val scalametaVersion = "4.7.8"
+val scalametaVersion = "4.8.5"
 
 object Deps {
   val acyclic = ivy"com.lihaoyi:::acyclic:0.3.8"


### PR DESCRIPTION
Includes:

https://github.com/scalameta/scalameta/pull/3178

CVEs:

    https://nvd.nist.gov/vuln/detail/CVE-2022-3510 (High: 7.5 CVSS)
    https://nvd.nist.gov/vuln/detail/CVE-2022-3509 (High: 7.5 CVSS)
    https://nvd.nist.gov/vuln/detail/CVE-2022-3171 (High: 7.5 CVSS)
