### PR TITLE
Fix recent regression with import hooks in blocks

### DIFF
--- a/amm/compiler/src/main/scala-2/ammonite/compiler/Parsers.scala
+++ b/amm/compiler/src/main/scala-2/ammonite/compiler/Parsers.scala
@@ -39,7 +39,7 @@ object Parsers extends IParser {
   }
 
   def ImportSplitter[_: P]: P[Seq[ammonite.util.ImportTree]] =
-    P( `import` ~/ ImportExpr.rep(1, sep = ","./) )
+    P( WL ~ `import` ~/ ImportExpr.rep(1, sep = ","./) )
 
   def ImportFinder[_: P]: P[String] =
     P(WL ~ `import` ~/ ImportExpr.! ~ End)

--- a/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/AdvancedTests.scala
@@ -708,6 +708,19 @@ object AdvancedTests extends TestSuite{
         """
       )
     }
+    test("hook in block") {
+      check.session(
+        """
+          @ {
+          @   import $ivy.`org.typelevel::cats-kernel:2.6.1`
+          @ }
+          import $ivy.$
+
+          @ import cats.kernel._
+          import cats.kernel._
+        """
+      )
+    }
     test("class-path-hook") {
       val sbv = check.scalaBinaryVersion
       check.session(


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/com-lihaoyi/Ammonite/pull/1361. This makes the following work again as expected:
```scala
@ {
    import $ivy.`org.typelevel::cats-kernel:2.6.1`
  }
```

Before the changes here, in Scala 2.x, one gets an error like
```text
cmd0.sc:2: object org.typelevel::cats-kernel:2.6.1 is not a member of package ammonite.$ivy
import $ivy.`org.typelevel::cats-kernel:2.6.1`
       ^
Compilation Failed
```