### PR TITLE
Call `.value` to get the actual typeName in Main

### DIFF
--- a/amm/src/main/scala/ammonite/Main.scala
+++ b/amm/src/main/scala/ammonite/Main.scala
@@ -125,7 +125,7 @@ case class Main(predefCode: String = "",
           .Internal
           .replArgs($idx)
           .value
-          .asInstanceOf[${b.typeName}]
+          .asInstanceOf[${b.typeName.value}]
         """
       }.mkString(newLine)
 


### PR DESCRIPTION
Forgot to call `.value` and the result was `.asInstanceOf[TypeName(Int)]` instead of `.asInstanceOf[Int]`