### PR TITLE
Update acyclic from 0.3.9 to 0.3.10

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -67,7 +67,7 @@ val fastparseVersion = "3.0.2"
 val scalametaVersion = "4.8.13"
 
 object Deps {
-  val acyclic = ivy"com.lihaoyi:::acyclic:0.3.9"
+  val acyclic = ivy"com.lihaoyi:::acyclic:0.3.10"
   val bsp4j = ivy"ch.epfl.scala:bsp4j:${bspVersion}"
   val bcprovJdk15on = ivy"org.bouncycastle:bcprov-jdk15on:1.56"
   val cask = ivy"com.lihaoyi::cask:0.6.0"


### PR DESCRIPTION
This unblocks update to Scala 2.12.19
