### PR TITLE
Add scala 3 compiler settings test

### DIFF
--- a/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
@@ -225,7 +225,7 @@ object BuiltinTests extends TestSuite {
           @ repl.initialContext.settings.explain.value(using repl.initialContext)
           res1: Boolean = false
 
-          @ interp.preConfigureCompiler(ctx => ctx.setSettings((dotty.tools.dotc.ScalacCommand.distill(scalacOptions.toArray, ctx.settings)(ctx.settingsState)(using ctx)).sstate))
+          @ interp.preConfigureCompiler(ctx => ctx.setSettings(ctx.settings.processArguments(scalacOptions, true, ctx.settingsState).sstate))
 
           @ repl.initialContext.settings.explain.value(using repl.initialContext)
           res3: Boolean = true

--- a/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
@@ -208,15 +208,15 @@ object BuiltinTests extends TestSuite {
     test("scalacOptions") {
       if (check.scala2)
         check.session("""
-          @ val scalacOptions = List("-Yrangepos:true")
+          @ val scalacOptions = List("-Yno-imports")
 
-          @ repl.compiler.settings.Yrangepos.value
+          @ repl.compiler.settings.noimports.value
           res1: Boolean = false
 
           @ interp.preConfigureCompiler(_.processArguments(scalacOptions, true))
 
-          @ repl.compiler.settings.Yrangepos.value
-          res3: Boolean = true
+          @ repl.compiler.settings.noimports.value
+          res3: scala.Boolean = true
         """)
       else
         check.session("""

--- a/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
@@ -143,7 +143,8 @@ object BuiltinTests extends TestSuite {
       // In 2.12.13, I would have expected things like
       //   interp.configureCompiler(_.settings.Wconf.tryToSet(List("any:wv", "cat=unchecked:ws")))
       // to re-instate the expected warning below, to no avail :|
-      if (TestUtils.scala2_12 && sv.stripPrefix("2.12.").toInt <= 12) check.session(s"""
+      if (TestUtils.scala2_12 && sv.stripPrefix("2.12.").toInt <= 12) {
+        check.session(s"""
         @ // Disabling default Scala imports
 
         @ List(1, 2, 3) + "lol"
@@ -190,6 +191,17 @@ object BuiltinTests extends TestSuite {
         @ repl.compiler.settings.nowarnings.value
         res10: Boolean = false
       """)
+      } else if (!check.scala2) {
+        check.session("""
+          @ object X extends Dynamic
+          error: extension of type scala.Dynamic needs to be enabled
+
+          @ interp.preConfigureCompiler(ctx => ctx.setSetting(ctx.settings.language, List("dynamics")))
+
+          @ object X extends Dynamic
+          defined object X
+        """)
+      }
     }
     test("infoLogging") {
       if (check.scala2)

--- a/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
@@ -203,6 +203,32 @@ object BuiltinTests extends TestSuite {
         """)
       }
     }
+    test("scalacOptions") {
+      if (check.scala2)
+        check.session("""
+          @ val scalacOptions = List("-Yrangepos:true")
+
+          @ repl.compiler.settings.Yrangepos.value
+          res1: Boolean = false
+
+          @ interp.preConfigureCompiler(_.processArguments(scalacOptions, true))
+
+          @ repl.compiler.settings.Yrangepos.value
+          res3: Boolean = true
+        """)
+      else
+        check.session("""
+          @ val scalacOptions = List("-explain")
+
+          @ repl.initialContext.settings.explain.value(using repl.initialContext)
+          res1: Boolean = false
+
+          @ interp.preConfigureCompiler(ctx => ctx.setSettings((dotty.tools.dotc.ScalacCommand.distill(scalacOptions.toArray, ctx.settings)(ctx.settingsState)(using ctx)).sstate))
+
+          @ repl.initialContext.settings.explain.value(using repl.initialContext)
+          res3: Boolean = true
+        """)
+    }
     test("infoLogging") {
       if (check.scala2)
         check.session("""

--- a/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
@@ -143,7 +143,7 @@ object BuiltinTests extends TestSuite {
       // In 2.12.13, I would have expected things like
       //   interp.configureCompiler(_.settings.Wconf.tryToSet(List("any:wv", "cat=unchecked:ws")))
       // to re-instate the expected warning below, to no avail :|
-      if (TestUtils.scala2_12 && sv.stripPrefix("2.12.").toInt <= 12) {
+      if (TestUtils.scala2_12 && sv.stripPrefix("2.12.").toInt <= 19) {
         check.session(s"""
         @ // Disabling default Scala imports
 

--- a/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/BuiltinTests.scala
@@ -152,6 +152,8 @@ object BuiltinTests extends TestSuite {
 
         @ interp.configureCompiler(_.settings.noimports.value = true)
 
+        @ // interp.preConfigureCompiler(ctx => ctx.setSetting(ctx.settings.YnoImports, true)) // Dotty
+
         @ List(1, 2, 3) + "lol" // predef imports disappear
         error: not found: value List
 


### PR DESCRIPTION
Official [Compiler Flags](https://ammonite.io/#CompilerFlags) documentation do not mention how to set settings for scala 3 compiler.

Maybe adding a comment like this in 2.12?:

```scala
@ // Disabling default Scala imports

@ List(1, 2, 3) + "lol"
res0: String = "List(1, 2, 3)lol"

@ interp.configureCompiler(_.settings.noimports.value = true)

@ // interp.preConfigureCompiler(ctx => ctx.setSetting(ctx.settings.YnoImports, true)) // Dotty
```

Fixes #1192