### PR TITLE
Avoid publishing binCrossScalaVersions cross-built modules for 3.4.2

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -63,7 +63,7 @@ val scala2Versions = scala2_12Versions ++ scala2_13Versions
 val scala3Versions = scala33Versions ++ scala34Versions
 
 val binCrossScalaVersions =
-  Seq(scala2_12Versions.last, scala2_13Versions.last, scala33Versions.last, scala34Versions.last)
+  Seq(scala2_12Versions.last, scala2_13Versions.last, scala33Versions.last)
 val assemblyCrossScalaVersions =
   Seq(scala2_12Versions.last, scala2_13Versions.last, scala33Versions.last, scala34Versions.last)
 def isScala2_12_10OrLater(sv: String): Boolean = {


### PR DESCRIPTION
We only want to publish for 3.3.x, because it is compatible with all future versions, whereas 3.4.x is not compatible with 3.3.x and causes conflicts when they both have the same `_3` suffix

Fixes https://github.com/com-lihaoyi/Ammonite/issues/1504
