### PR TITLE
Shrink CI matrix

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -30,7 +30,7 @@ jobs:
             command: 'amm[2.12.19].__.test'
 
           - java-version: 17
-            command: 'terminal[2.13.].__.test'
+            command: 'terminal[2.13].__.test'
           - java-version: 17
             command: 'amm.repl[2.13.14].__.test'
           - java-version: 17

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,53 +18,61 @@ jobs:
       fail-fast: false
       matrix:
         java-version: [ 8, 17 ]
-        scala-binary-version: [ 2.12, 2.13, 3.3, 3.4.2 ]
+        scala-version: [ 2.12, 2.13, 3.3, 3.4.2 ]
         include:
-          # Including lowest/highest versions that work with Java 21
-          - java-version: 21
-            scala-version: 2.12.18
-          - java-version: 21
-            scala-version: 2.12.19
-          - java-version: 21
-            scala-version: 2.13.11
-          - java-version: 21
-            scala-version: 2.13.14
-          - java-version: 21
-            scala-version: 3.3.1
-          - java-version: 21
-            scala-version: 3.3.3
-          - java-version: 21
-            scala-version: 3.4.2
+          - java-version: 8
+            command: 'terminal[2.12].__.test'
+          - java-version: 8
+            command: 'amm.repl[2.12.19].__.test'
+          - java-version: 8
+            command: 'amm.ssh[2.12.19].__.test'
+          - java-version: 8
+            command: 'amm[2.12.19].__.test'
+
+          - java-version: 17
+            command: 'terminal[2.13.].__.test'
+          - java-version: 17
+            command: 'amm.repl[2.13.14].__.test'
+          - java-version: 17
+            command: 'amm.ssh[2.13.14].__.test'
+          - java-version: 17
+            command: 'amm[2.13.14].__.test'
+
+          - java-version: 11
+            command: 'terminal[3].__.test'
+          - java-version: 11
+            command: 'amm.repl[3.3.3].__.test'
+          - java-version: 11
+            command: 'amm.ssh[3.3.3].__.test'
+          - java-version: 11
+            command: 'amm[3.3.3].__.test'
+
+          - java-version: 11
+            command: 'amm.repl[3.4.2].__.test'
+          - java-version: 11
+            command: 'amm.ssh[3.4.2].__.test'
+          - java-version: 11
+            command: 'amm[3.4.2].__.test'
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
           distribution: temurin
-      - run: ./mill -i -k unitTest "${{ matrix.scala-version }}"
+      - run: ./mill -i -k "${{ matrix.command }}"
 
   itest:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [ 8, 17 ]
-        scala-version: [ 2.12, 2.13, 3.3, 3.4.2 ]
         include:
-          # Including lowest/highest versions that work with Java 21
-          - java-version: 21
-            scala-version: 2.12.18
-          - java-version: 21
+          - java-version: 8
             scala-version: 2.12.19
-          - java-version: 21
-            scala-version: 2.13.11
-          - java-version: 21
+          - java-version: 17
             scala-version: 2.13.14
-          - java-version: 21
-            scala-version: 3.3.1
-          - java-version: 21
+          - java-version: 11
             scala-version: 3.3.3
           - java-version: 21
             scala-version: 3.4.2
@@ -78,7 +86,7 @@ jobs:
         with:
           java-version: ${{ matrix.java-version }}
           distribution: temurin
-      - run: ./mill -i -k integrationTest ${{ matrix.scala-version }}
+      - run: ./mill -i -k 'integration[${{ matrix.scala-version }}].__.test'
 
   site:
     runs-on: ubuntu-latest
@@ -103,8 +111,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: actions/setup-java@v4
         with:
           java-version: 8

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,39 +18,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - java-version: 8
-            command: 'terminal[2.12.19].__.test'
-          - java-version: 8
-            command: 'amm.repl[2.12.{9,11,13,15,17,19}].__.test'
-          - java-version: 8
-            command: 'sshd[2.12.19].__.test'
-          - java-version: 8
-            command: 'amm[2.12.{9,11,13,15,17,19}].__.test'
+          - java-version: 11
+            command: 'terminal.__.test'
 
-          - java-version: 17
-            command: 'terminal[2.13.14].__.test'
+          - java-version: 11
+            command: 'sshd[{2.12.19,2.13.14,3.3.3,3.4.2}].__.test'
+
+          - java-version: 11
+            command: 'amm.repl[2.12.{9,11,13,15,17,19}].__.test'
           - java-version: 17
             command: 'amm.repl[2.13.{4,6,8,10,12,14}].__.test'
-          - java-version: 17
-            command: 'sshd[2.13.14].__.test'
+          - java-version: 21
+            command: 'amm.repl[{3.3.{0,1,2,3},3.4.2}].__.test'
+
+          - java-version: 11
+            command: 'amm[2.12.{9,11,13,15,17,19}].__.test'
           - java-version: 17
             command: 'amm[2.13.{4,6,8,10,12,14}].__.test'
-
-          - java-version: 11
-            command: 'terminal[3.3.3].__.test'
-          - java-version: 11
-            command: 'amm.repl[3.3.{0,1,2,3}].__.test'
-          - java-version: 11
-            command: 'sshd[3.3.3].__.test'
-          - java-version: 11
-            command: 'amm[3.3.{0,1,2,3}].__.test'
-
-          - java-version: 11
-            command: 'amm.repl[3.4.2].__.test'
-          - java-version: 11
-            command: 'sshd[3.4.2].__.test'
-          - java-version: 11
-            command: 'amm[3.4.2].__.test'
+          - java-version: 21
+            command: 'amm[{3.3.{0,1,2,3},3.4.2}].__.test'
 
     runs-on: ubuntu-latest
     steps:
@@ -59,7 +45,7 @@ jobs:
         with:
           java-version: ${{ matrix.java-version }}
           distribution: temurin
-      - run: ./mill -i -k "${{ matrix.command }}"
+      - run: ./mill -i -k -j4 "${{ matrix.command }}"
 
   itest:
     strategy:
@@ -84,7 +70,7 @@ jobs:
         with:
           java-version: ${{ matrix.java-version }}
           distribution: temurin
-      - run: ./mill -i -k 'integration[${{ matrix.scala-version }}].__.test'
+      - run: ./mill -i -k -j4 'integration[${{ matrix.scala-version }}].__.test'
 
   site:
     runs-on: ubuntu-latest
@@ -101,7 +87,7 @@ jobs:
         env:
           TERM: xterm-256color
 
-  publishLocal:
+  compileAll:
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -111,7 +97,7 @@ jobs:
         with:
           java-version: 8
           distribution: temurin
-      - run: ./mill -i -k '__.publishLocal'
+      - run: ./mill -i -k -j4 '__.compile'
 
   release:
     if: github.repository == 'com-lihaoyi/Ammonite' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/2.x')

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -21,20 +21,20 @@ jobs:
           - java-version: 8
             command: 'terminal[2.12.19].__.test'
           - java-version: 8
-            command: 'amm.repl[2.12.{9,10,11,12,13,14,15,16,17,18,19}].__.test'
+            command: 'amm.repl[2.12.{9,11,13,15,17,19}].__.test'
           - java-version: 8
             command: 'amm.ssh[2.12.19].__.test'
           - java-version: 8
-            command: 'amm[2.12.{9,10,11,12,13,14,15,16,17,18,19}].__.test'
+            command: 'amm[2.12.{9,11,13,15,17,19}].__.test'
 
           - java-version: 17
             command: 'terminal[2.13.14].__.test'
           - java-version: 17
-            command: 'amm.repl[2.13.{4,5,6,7,8,9,10,11,12,13,14}].__.test'
+            command: 'amm.repl[2.13.{4,6,8,10,12,14}].__.test'
           - java-version: 17
             command: 'amm.ssh[2.13.14].__.test'
           - java-version: 17
-            command: 'amm[2.13.{4,5,6,7,8,9,10,11,12,13,14}].__.test'
+            command: 'amm[2.13.{4,6,8,10,12,14}].__.test'
 
           - java-version: 11
             command: 'terminal[3.3.3].__.test'
@@ -105,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala-version: [ '2.12.{9,10,11,12,13,14,15,16,17,18,19}', '2.13.{4,5,6,7,8,9,10,11,12,13,14}', '3.3.{0,1,2,3}', 3.4.2 ]
+        scala-version: [ '2.12.{9,11,13,15,17,19}', '2.13.{4,6,8,10,12,14}', '3.3.{0,1,2,3}', 3.4.2 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -111,6 +111,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-java@v4
         with:
           java-version: 8

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -111,7 +111,7 @@ jobs:
         with:
           java-version: 8
           distribution: temurin
-      - run: ./mill -i -k '__[__].__.publishLocal'
+      - run: ./mill -i -k '__.publishLocal'
 
   release:
     if: github.repository == 'com-lihaoyi/Ammonite' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/2.x')

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -23,7 +23,7 @@ jobs:
           - java-version: 8
             command: 'amm.repl[2.12.{9,11,13,15,17,19}].__.test'
           - java-version: 8
-            command: 'ssh[2.12.19].__.test'
+            command: 'sshd[2.12.19].__.test'
           - java-version: 8
             command: 'amm[2.12.{9,11,13,15,17,19}].__.test'
 
@@ -32,7 +32,7 @@ jobs:
           - java-version: 17
             command: 'amm.repl[2.13.{4,6,8,10,12,14}].__.test'
           - java-version: 17
-            command: 'ssh[2.13.14].__.test'
+            command: 'sshd[2.13.14].__.test'
           - java-version: 17
             command: 'amm[2.13.{4,6,8,10,12,14}].__.test'
 
@@ -41,14 +41,14 @@ jobs:
           - java-version: 11
             command: 'amm.repl[3.3.{0,1,2,3}].__.test'
           - java-version: 11
-            command: 'ssh[3.3.3].__.test'
+            command: 'sshd[3.3.3].__.test'
           - java-version: 11
             command: 'amm[3.3.{0,1,2,3}].__.test'
 
           - java-version: 11
             command: 'amm.repl[3.4.2].__.test'
           - java-version: 11
-            command: 'ssh[3.4.2].__.test'
+            command: 'sshd[3.4.2].__.test'
           - java-version: 11
             command: 'amm[3.4.2].__.test'
 
@@ -104,8 +104,6 @@ jobs:
   publishLocal:
     strategy:
       fail-fast: false
-      matrix:
-        scala-version: [ '2.12.{9,11,13,15,17,19}', '2.13.{4,6,8,10,12,14}', '3.3.{0,1,2,3}', 3.4.2 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -113,7 +111,7 @@ jobs:
         with:
           java-version: 8
           distribution: temurin
-      - run: ./mill -i -k '__[${{ matrix.scala-version }}].__.publishLocal'
+      - run: ./mill -i -k '__[__].__.publishLocal'
 
   release:
     if: github.repository == 'com-lihaoyi/Ammonite' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/2.x')

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -111,8 +111,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: actions/setup-java@v4
         with:
           java-version: 8

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -113,7 +113,7 @@ jobs:
         with:
           java-version: 8
           distribution: temurin
-      - run: ./mill -i -k __[${{ matrix.scala-version }}].__.publishLocal
+      - run: ./mill -i -k '__[${{ matrix.scala-version }}].__.publishLocal'
 
   release:
     if: github.repository == 'com-lihaoyi/Ammonite' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/2.x')

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -23,7 +23,7 @@ jobs:
           - java-version: 8
             command: 'amm.repl[2.12.{9,11,13,15,17,19}].__.test'
           - java-version: 8
-            command: 'amm.ssh[2.12.19].__.test'
+            command: 'ssh[2.12.19].__.test'
           - java-version: 8
             command: 'amm[2.12.{9,11,13,15,17,19}].__.test'
 
@@ -32,7 +32,7 @@ jobs:
           - java-version: 17
             command: 'amm.repl[2.13.{4,6,8,10,12,14}].__.test'
           - java-version: 17
-            command: 'amm.ssh[2.13.14].__.test'
+            command: 'ssh[2.13.14].__.test'
           - java-version: 17
             command: 'amm[2.13.{4,6,8,10,12,14}].__.test'
 
@@ -41,14 +41,14 @@ jobs:
           - java-version: 11
             command: 'amm.repl[3.3.{0,1,2,3}].__.test'
           - java-version: 11
-            command: 'amm.ssh[3.3.3].__.test'
+            command: 'ssh[3.3.3].__.test'
           - java-version: 11
             command: 'amm[3.3.{0,1,2,3}].__.test'
 
           - java-version: 11
             command: 'amm.repl[3.4.2].__.test'
           - java-version: 11
-            command: 'amm.ssh[3.4.2].__.test'
+            command: 'ssh[3.4.2].__.test'
           - java-version: 11
             command: 'amm[3.4.2].__.test'
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -67,11 +67,11 @@ jobs:
       matrix:
         include:
           - java-version: 8
-            scala-version: 2.12.19
+            scala-version: '2.12.{9,11,13,15,17,19}'
           - java-version: 17
-            scala-version: 2.13.14
+            scala-version: '2.13.{4,6,8,10,12,14}'
           - java-version: 11
-            scala-version: 3.3.3
+            scala-version: '3.3.{0,1,2,3}'
           - java-version: 21
             scala-version: 3.4.2
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -17,35 +17,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [ 8, 17 ]
-        scala-version: [ 2.12, 2.13, 3.3, 3.4.2 ]
         include:
           - java-version: 8
-            command: 'terminal[2.12].__.test'
+            command: 'terminal[2.12.19].__.test'
           - java-version: 8
-            command: 'amm.repl[2.12.19].__.test'
+            command: 'amm.repl[2.12.{9,10,11,12,13,14,15,16,17,18,19}].__.test'
           - java-version: 8
             command: 'amm.ssh[2.12.19].__.test'
           - java-version: 8
-            command: 'amm[2.12.19].__.test'
+            command: 'amm[2.12.{9,10,11,12,13,14,15,16,17,18,19}].__.test'
 
           - java-version: 17
-            command: 'terminal[2.13].__.test'
+            command: 'terminal[2.13.14].__.test'
           - java-version: 17
-            command: 'amm.repl[2.13.14].__.test'
+            command: 'amm.repl[2.13.{4,5,6,7,8,9,10,11,12,13,14}].__.test'
           - java-version: 17
             command: 'amm.ssh[2.13.14].__.test'
           - java-version: 17
-            command: 'amm[2.13.14].__.test'
+            command: 'amm[2.13.{4,5,6,7,8,9,10,11,12,13,14}].__.test'
 
           - java-version: 11
-            command: 'terminal[3].__.test'
+            command: 'terminal[3.3.3].__.test'
           - java-version: 11
-            command: 'amm.repl[3.3.3].__.test'
+            command: 'amm.repl[3.3.{0,1,2,3}].__.test'
           - java-version: 11
             command: 'amm.ssh[3.3.3].__.test'
           - java-version: 11
-            command: 'amm[3.3.3].__.test'
+            command: 'amm[3.3.{0,1,2,3}].__.test'
 
           - java-version: 11
             command: 'amm.repl[3.4.2].__.test'
@@ -107,7 +105,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala-version: [ 2.12.19, 2.13.14, 3.3.3, 3.4.2 ]
+        scala-version: [ '2.12.{9,10,11,12,13,14,15,16,17,18,19}', '2.13.{4,5,6,7,8,9,10,11,12,13,14}', '3.3.{0,1,2,3}', 3.4.2 ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,7 +36,7 @@ jobs:
           - java-version: 17
             command: 'amm[2.13.{4,9,14}].__.test'
           - java-version: 21
-            command: 'amm[{3.3.0,3,3,3,3.4.2}].__.test'
+            command: 'amm[{3.3.0,3.3.3,3.4.2}].__.test'
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -99,7 +99,7 @@ jobs:
 
   release:
     if: github.repository == 'com-lihaoyi/Ammonite' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/2.x')
-    needs: [ test, itest, site, publishLocal ]
+    needs: [ test, itest, site, compileAll ]
     uses: ./.github/workflows/release.yml
     secrets: inherit
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Run Tests
 on:
   push:
     branches:
@@ -105,7 +105,7 @@ jobs:
     uses: ./.github/workflows/release.yml
     secrets: inherit
 
-  publishDosc:
+  publishDocs:
     if: github.repository == 'com-lihaoyi/Ammonite' && github.ref == 'refs/heads/main'
     needs: [ test, itest, site ]
     uses: ./.github/workflows/publishDocs.yml

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           java-version: ${{ matrix.java-version }}
           distribution: temurin
-      - run: ./mill -i -k -j4 'integration[${{ matrix.scala-version }}].__.test'
+      - run: ./mill -i -k 'integration[${{ matrix.scala-version }}].__.test'
 
   site:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,18 +25,18 @@ jobs:
             command: 'sshd[{2.12.19,2.13.14,3.3.3,3.4.2}].__.test'
 
           - java-version: 11
-            command: 'amm.repl[2.12.{9,11,13,15,17,19}].__.test'
+            command: 'amm.repl[2.12.{9,14,19}].__.test'
           - java-version: 17
-            command: 'amm.repl[2.13.{4,6,8,10,12,14}].__.test'
+            command: 'amm.repl[2.13.{4,9,14}].__.test'
           - java-version: 21
-            command: 'amm.repl[{3.3.{0,1,2,3},3.4.2}].__.test'
+            command: 'amm.repl[{3.3.0,3.3.3,3.4.2}].__.test'
 
           - java-version: 11
-            command: 'amm[2.12.{9,11,13,15,17,19}].__.test'
+            command: 'amm[2.12.{9,14,19}].__.test'
           - java-version: 17
-            command: 'amm[2.13.{4,6,8,10,12,14}].__.test'
+            command: 'amm[2.13.{4,9,14}].__.test'
           - java-version: 21
-            command: 'amm[{3.3.{0,1,2,3},3.4.2}].__.test'
+            command: 'amm[{3.3.0,3,3,3,3.4.2}].__.test'
 
     runs-on: ubuntu-latest
     steps:
@@ -52,14 +52,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - java-version: 8
-            scala-version: '2.12.{9,11,13,15,17,19}'
-          - java-version: 17
-            scala-version: '2.13.{4,6,8,10,12,14}'
           - java-version: 11
-            scala-version: '3.3.{0,1,2,3}'
+            scala-version: '2.12.{9,14,19}'
+          - java-version: 17
+            scala-version: '2.13.{4,9,14}'
           - java-version: 21
-            scala-version: 3.4.2
+            scala-version: '{3.3.0,3.3.3,3.4.2}'
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,14 +29,14 @@ jobs:
           - java-version: 17
             command: 'amm.repl[2.13.{4,9,14}].__.test'
           - java-version: 21
-            command: 'amm.repl[{3.3.0,3.3.3,3.4.2}].__.test'
+            command: 'amm.repl[{3.3.3,3.4.2}].__.test'
 
           - java-version: 11
             command: 'amm[2.12.{9,14,19}].__.test'
           - java-version: 17
             command: 'amm[2.13.{4,9,14}].__.test'
           - java-version: 21
-            command: 'amm[{3.3.0,3.3.3,3.4.2}].__.test'
+            command: 'amm[{3.3.3,3.4.2}].__.test'
 
     runs-on: ubuntu-latest
     steps:
@@ -57,7 +57,7 @@ jobs:
           - java-version: 17
             scala-version: '2.13.{4,9,14}'
           - java-version: 21
-            scala-version: '{3.3.0,3.3.3,3.4.2}'
+            scala-version: '{3.3.3,3.4.2}'
 
     runs-on: ubuntu-latest
     steps:

--- a/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
@@ -184,8 +184,11 @@ object ProjectTests extends TestSuite {
     }
 
     test("finagle") {
+      val s = new java.net.ServerSocket(0);
+      val port = s.getLocalPort
+      s.close()
       // Prevent regressions when wildcard-importing things called `macro` or `_`
-      check.session("""
+      check.session(s"""
         @ import $ivy.`com.twitter::finagle-http:21.4.0 compat`
 
         @ import com.twitter.finagle._, com.twitter.util._
@@ -203,9 +206,9 @@ object ProjectTests extends TestSuite {
         @   }
         @ }
 
-        @ val server = Http.serve(":8080", service)
+        @ val server = Http.serve(":$port", service)
 
-        @ val client: Service[http.Request, http.Response] = Http.client.newService(":8080")
+        @ val client: Service[http.Request, http.Response] = Http.client.newService(":$port")
 
         @ val request = http.Request(http.Method.Get, "/")
 

--- a/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
+++ b/amm/repl/src/test/scala/ammonite/session/ProjectTests.scala
@@ -189,7 +189,7 @@ object ProjectTests extends TestSuite {
       s.close()
       // Prevent regressions when wildcard-importing things called `macro` or `_`
       check.session(s"""
-        @ import $ivy.`com.twitter::finagle-http:21.4.0 compat`
+        @ import $$ivy.`com.twitter::finagle-http:21.4.0 compat`
 
         @ import com.twitter.finagle._, com.twitter.util._
 

--- a/build.sc
+++ b/build.sc
@@ -33,7 +33,11 @@ val isPublishableCommit =
       publishBranches.exists(suffix => x.endsWith(s"/${suffix}"))
     )
 
-val latestTaggedVersion = os.proc("git", "describe", "--abbrev=0", "--tags").call().out.trim
+val latestTaggedVersion = try{
+  os.proc("git", "describe", "--abbrev=0", "--tags").call().out.trim
+}catch{case e: os.SubprocessException =>
+  "dev"
+}
 
 val gitHead = os.proc("git", "rev-parse", "HEAD").call().out.trim
 

--- a/build.sc
+++ b/build.sc
@@ -41,12 +41,14 @@ val latestTaggedVersion = try{
 
 val gitHead = os.proc("git", "rev-parse", "HEAD").call().out.trim
 
-val commitsSinceTaggedVersion = {
-  os.proc("git", "rev-list", gitHead, "--not", latestTaggedVersion, "--count")
-    .call()
-    .out
-    .trim
-    .toInt
+val commitsSinceTaggedVersion = latestTaggedVersion match{
+  case "dev" => 0
+  case latest =>
+    os.proc("git", "rev-list", gitHead, "--not", latest, "--count")
+      .call()
+      .out
+      .trim
+      .toInt
 }
 
 //val isJava21 = scala.util.Properties.isJavaAtLeast(21).tap {


### PR DESCRIPTION
* We probably only need to each on each Java and Scala version once, rather than on the full cross matrix of all combinations. 
* We probably don't need to test every PR with every single Scala version. For now, for each Scala major version I picked three minor versions: highest, lowest, and one in the middle. 
* Replaced `__.publishLocal` with `__.compile`, which should hopefully catch most of the same bugs but be much cheaper not creating jars
* I suspect the `unitTest` and `integrationTest` helper tasks were not doing the right thing - they were taking far longer than they should have been taking - but I couldn't figure out why. For now I just ditched them and use Mill queries to select the tests I want manually
* Turned on Mill parallelism
* We drop CI for Java 8, in line with the rest of the com-lihaoyi ecosystem

Hopefully that will give us enough confidence that things mostly work, and if anything emerges that's super version specific we can fix it ad-hoc without needing to wait 40+ hours of CPU time for every PR to be validated