### PR TITLE
Add support for Scala 2.13.15

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,19 +22,19 @@ jobs:
             command: 'terminal.__.test'
 
           - java-version: 11
-            command: 'sshd[{2.12.20,2.13.14,3.4.3,3.5.1}].__.test'
+            command: 'sshd[{2.12.20,2.13.15,3.4.3,3.5.1}].__.test'
 
           - java-version: 11
             command: 'amm.repl[2.12.{9,14,20}].__.test'
           - java-version: 17
-            command: 'amm.repl[2.13.{4,9,14}].__.test'
+            command: 'amm.repl[2.13.{4,9,15}].__.test'
           - java-version: 21
             command: 'amm.repl[{3.4.3,3.5.1}].__.test'
 
           - java-version: 11
             command: 'amm[2.12.{9,14,20}].__.test'
           - java-version: 17
-            command: 'amm[2.13.{4,9,14}].__.test'
+            command: 'amm[2.13.{4,9,15}].__.test'
           - java-version: 21
             command: 'amm[{3.4.3,3.5.1}].__.test'
 
@@ -55,7 +55,7 @@ jobs:
           - java-version: 11
             scala-version: '2.12.{9,14,20}'
           - java-version: 17
-            scala-version: '2.13.{4,9,14}'
+            scala-version: '2.13.{4,9,15}'
           - java-version: 21
             scala-version: '{3.4.3,3.5.1}'
 

--- a/build.sc
+++ b/build.sc
@@ -102,7 +102,7 @@ val fastparseVersion = "3.1.1"
 val scalametaVersion = "4.9.7"
 
 object Deps {
-  val acyclic = ivy"com.lihaoyi:::acyclic:0.3.13"
+  val acyclic = ivy"com.lihaoyi:::acyclic:0.3.14"
   val bsp4j = ivy"ch.epfl.scala:bsp4j:${bspVersion}"
   val bcprovJdk15on = ivy"org.bouncycastle:bcprov-jdk18on:1.78.1"
   val cask = ivy"com.lihaoyi::cask:0.9.1"

--- a/build.sc
+++ b/build.sc
@@ -58,7 +58,7 @@ val commitsSinceTaggedVersion = latestTaggedVersion match{
 val scala2_12Versions = 9.to(20)
 //  .dropWhile(v => isJava21 && v < 18)
   .map(v => s"2.12.${v}")
-val scala2_13Versions = 2.to(14)
+val scala2_13Versions = 2.to(15)
 //  .dropWhile(v => isJava21 && v < 11)
   .map(v => s"2.13.${v}")
 // TODO: We can't have 3.4.0 & 3.4.1 until we solve https://github.com/com-lihaoyi/Ammonite/issues/1395


### PR DESCRIPTION
https://contributors.scala-lang.org/t/scala-2-13-15-release-planning/6649/10
<img width="775" alt="image" src="https://github.com/user-attachments/assets/338b022e-468b-4cdf-a927-2aaaa4eb1348">

`Scala 2.13.15` has been released, let's support it.

Depends on

- [] https://github.com/com-lihaoyi/acyclic/pull/138
- [] https://github.com/typelevel/kind-projector/pull/291