### PR TITLE
Fix a Scala 3 completion error

### DIFF
--- a/amm/compiler/src/main/scala-3.0.0-3.3.1/dotty/ammonite/compiler/AmmCompletion.scala
+++ b/amm/compiler/src/main/scala-3.0.0-3.3.1/dotty/ammonite/compiler/AmmCompletion.scala
@@ -6,6 +6,7 @@ import dotty.tools.dotc.core.Contexts._
 import dotty.tools.dotc.core.Denotations.SingleDenotation
 import dotty.tools.dotc.core.Flags._
 import dotty.tools.dotc.core.Names.Name
+import dotty.tools.dotc.core.Phases
 import dotty.tools.dotc.core.Symbols.{Symbol, defn}
 import dotty.tools.dotc.interactive.{Completion, Interactive}
 import dotty.tools.dotc.util.SourcePosition
@@ -23,7 +24,7 @@ object AmmCompletion extends AmmCompletionExtras {
       path,
       dependencyCompleteOpt,
       enableDeep
-    )(using Interactive.contextOfPath(path))
+    )(using Interactive.contextOfPath(path).withPhase(Phases.typerPhase))
   }
 
   def computeCompletions(

--- a/amm/compiler/src/main/scala-3.3.2+/dotty/ammonite/compiler/AmmCompletion.scala
+++ b/amm/compiler/src/main/scala-3.3.2+/dotty/ammonite/compiler/AmmCompletion.scala
@@ -6,6 +6,7 @@ import dotty.tools.dotc.core.Contexts._
 import dotty.tools.dotc.core.Denotations.SingleDenotation
 import dotty.tools.dotc.core.Flags._
 import dotty.tools.dotc.core.Names.Name
+import dotty.tools.dotc.core.Phases
 import dotty.tools.dotc.core.Symbols.{Symbol, defn}
 import dotty.tools.dotc.interactive.{Completion, Interactive}
 import dotty.tools.dotc.util.SourcePosition
@@ -23,7 +24,7 @@ object AmmCompletion extends AmmCompletionExtras {
       path,
       dependencyCompleteOpt,
       enableDeep
-    )(using Interactive.contextOfPath(path))
+    )(using Interactive.contextOfPath(path).withPhase(Phases.typerPhase))
   }
 
   def computeCompletions(

--- a/amm/compiler/src/main/scala-3.4.2+/dotty/ammonite/compiler/AmmCompletion.scala
+++ b/amm/compiler/src/main/scala-3.4.2+/dotty/ammonite/compiler/AmmCompletion.scala
@@ -6,6 +6,7 @@ import dotty.tools.dotc.core.Contexts._
 import dotty.tools.dotc.core.Denotations.SingleDenotation
 import dotty.tools.dotc.core.Flags._
 import dotty.tools.dotc.core.Names.Name
+import dotty.tools.dotc.core.Phases
 import dotty.tools.dotc.core.Symbols.{Symbol, defn}
 import dotty.tools.dotc.interactive.{Completion, Interactive}
 import dotty.tools.dotc.util.SourcePosition
@@ -23,7 +24,7 @@ object AmmCompletion extends AmmCompletionExtras {
       path,
       dependencyCompleteOpt,
       enableDeep
-    )(using Interactive.contextOfPath(path))
+    )(using Interactive.contextOfPath(path).withPhase(Phases.typerPhase))
   }
 
   def computeCompletions(

--- a/amm/compiler/src/main/scala-3.5.0+/dotty/ammonite/compiler/AmmCompletion.scala
+++ b/amm/compiler/src/main/scala-3.5.0+/dotty/ammonite/compiler/AmmCompletion.scala
@@ -6,6 +6,7 @@ import dotty.tools.dotc.core.Contexts._
 import dotty.tools.dotc.core.Denotations.SingleDenotation
 import dotty.tools.dotc.core.Flags._
 import dotty.tools.dotc.core.Names.Name
+import dotty.tools.dotc.core.Phases
 import dotty.tools.dotc.core.Symbols.{Symbol, defn}
 import dotty.tools.dotc.interactive.{Completion, Interactive}
 import dotty.tools.dotc.util.SourcePosition
@@ -23,7 +24,7 @@ object AmmCompletion extends AmmCompletionExtras {
       path,
       dependencyCompleteOpt,
       enableDeep
-    )(using Interactive.contextOfPath(path))
+    )(using Interactive.contextOfPath(path).withPhase(Phases.typerPhase))
   }
 
   def computeCompletions(


### PR DESCRIPTION
Fix #1567
Fix #1538

I'm actually not sure what causes the crash or what this fix does to fix that. The `AmmCompletion.scala` file seemed to be copied from dotty's `interactive/Completions.scala` and adding [this](https://github.com/scala/scala3/blob/8ab7ebefecfd3d7b1e23a47238556c125ed795e8/compiler/src/dotty/tools/dotc/interactive/Completion.scala#L57) fixes the crash.

Tested manually for Scala 3.5.1, 3.4.3, 3.3.4.