### PR TITLE
Use JDK 11 in CI jobs that were still on JDK 8

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -82,7 +82,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@v4
         with:
-          java-version: 8
+          java-version: 11
           distribution: temurin
       - name: Setup sbt launcher
         uses: sbt/setup-sbt@v1
@@ -99,6 +99,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: 8
+          java-version: 11
           distribution: temurin
       - run: ./mill -i -k -j4 '__.compile'


### PR DESCRIPTION
Seems upcoming Mill versions require JDK >= 11, see the CI failures of https://github.com/com-lihaoyi/Ammonite/pull/1608